### PR TITLE
Update all examples to Aztec v3.0.0-devnet.6-patch.1

### DIFF
--- a/.github/workflows/note-send-proof-tests.yml
+++ b/.github/workflows/note-send-proof-tests.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       AZTEC_ENV: local-network
-      AZTEC_VERSION: 3.0.0-devnet.20251212
+      AZTEC_VERSION: 3.0.0-devnet.6-patch.1
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/prediction-market-tests.yml
+++ b/.github/workflows/prediction-market-tests.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       AZTEC_ENV: local-network
-      AZTEC_VERSION: 3.0.0-devnet.20251212
+      AZTEC_VERSION: 3.0.0-devnet.6-patch.1
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/test-wallet-webapp-tests.yml
+++ b/.github/workflows/test-wallet-webapp-tests.yml
@@ -17,7 +17,7 @@ jobs:
     name: Test Wallet Webapp Tests
     runs-on: ubuntu-latest
     env:
-      AZTEC_VERSION: 3.0.0-devnet.20251212
+      AZTEC_VERSION: 3.0.0-devnet.6-patch.1
 
     steps:
       - name: Checkout repository

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -259,9 +259,9 @@ aztec = { git = "https://github.com/AztecProtocol/aztec-packages/", tag = "vX.X.
 easy_private_state = { git = "https://github.com/AztecProtocol/aztec-packages/", tag = "vX.X.X", directory = "noir-projects/aztec-nr/easy-private-state" }
 ```
 
-**Version Compatibility**: Different examples may use different Aztec versions:
+**Version Compatibility**: All examples use the same Aztec version:
 
-- `recursive_verification`: v3.0.0-devnet.6-patch.1
+- All examples: v3.0.0-devnet.6-patch.1
 
 ### JavaScript/TypeScript Dependencies
 

--- a/account-contract/Nargo.toml
+++ b/account-contract/Nargo.toml
@@ -5,4 +5,4 @@ compiler_version = ">=1.0.0"
 type = "contract"
 
 [dependencies]
-aztec = { git = "https://github.com/AztecProtocol/aztec-packages/", tag = "v3.0.0-devnet.20251212", directory = "noir-projects/aztec-nr/aztec" }
+aztec = { git = "https://github.com/AztecProtocol/aztec-nr/", tag = "v3.0.0-devnet.6-patch.1", directory = "aztec" }

--- a/account-contract/README.md
+++ b/account-contract/README.md
@@ -172,25 +172,25 @@ When implementing custom account contracts in Aztec, be aware of these critical 
 
 ## Aztec Version Compatibility
 
-This example is compatible with **Aztec v3.0.0-devnet.20251212**.
+This example is compatible with **Aztec v3.0.0-devnet.6-patch.1**.
 
 To set this version:
 
 ```bash
-aztec-up 3.0.0-devnet.20251212
+aztec-up 3.0.0-devnet.6-patch.1
 ```
 
 ## Dependencies
 
 ### Noir Dependencies
 
-- **aztec**: v3.0.0-devnet.20251212
+- **aztec**: v3.0.0-devnet.6-patch.1
 
 ### TypeScript Dependencies
 
-- **@aztec/aztec.js**: 3.0.0-devnet.20251212
-- **@aztec/accounts**: 3.0.0-devnet.20251212
-- **@aztec/stdlib**: 3.0.0-devnet.20251212
+- **@aztec/aztec.js**: 3.0.0-devnet.6-patch.1
+- **@aztec/accounts**: 3.0.0-devnet.6-patch.1
+- **@aztec/stdlib**: 3.0.0-devnet.6-patch.1
 - **@aztec/entrypoints**: Included in aztec.js
 
 ## Project Structure

--- a/account-contract/package.json
+++ b/account-contract/package.json
@@ -12,12 +12,12 @@
     "typescript": "^5.0.0"
   },
   "dependencies": {
-    "@aztec/accounts": "3.0.0-devnet.20251212",
-    "@aztec/aztec.js": "3.0.0-devnet.20251212",
-    "@aztec/foundation": "3.0.0-devnet.20251212",
-    "@aztec/noir-contracts.js": "3.0.0-devnet.20251212",
-    "@aztec/stdlib": "3.0.0-devnet.20251212",
-    "@aztec/test-wallet": "3.0.0-devnet.20251212",
+    "@aztec/accounts": "3.0.0-devnet.6-patch.1",
+    "@aztec/aztec.js": "3.0.0-devnet.6-patch.1",
+    "@aztec/foundation": "3.0.0-devnet.6-patch.1",
+    "@aztec/noir-contracts.js": "3.0.0-devnet.6-patch.1",
+    "@aztec/stdlib": "3.0.0-devnet.6-patch.1",
+    "@aztec/test-wallet": "3.0.0-devnet.6-patch.1",
     "tsx": "^4.20.6"
   }
 }

--- a/account-contract/yarn.lock
+++ b/account-contract/yarn.lock
@@ -575,59 +575,59 @@
   resolved "https://registry.yarnpkg.com/@aws/lambda-invoke-store/-/lambda-invoke-store-0.1.1.tgz#2e67f17040b930bde00a79ffb484eb9e77472b06"
   integrity sha512-RcLam17LdlbSOSp9VxmUu1eI6Mwxp+OwhD2QhiSNmNCzoDb0EeUXTD2n/WbcnrAYMGlmf05th6QYq23VqvJqpA==
 
-"@aztec/accounts@3.0.0-devnet.20251212":
-  version "3.0.0-devnet.20251212"
-  resolved "https://registry.yarnpkg.com/@aztec/accounts/-/accounts-3.0.0-devnet.20251212.tgz#9bbc3097a7e0579e922a87880eaea760ac0e718c"
-  integrity sha512-nmXLe6N45F/V6SZWgLEvU2h58vC23eYUtuHROnaLBzh579DUv2TTSxSF8BU/1hKPKCYaloLWXy7z7F6WVMZaVg==
+"@aztec/accounts@3.0.0-devnet.6-patch.1":
+  version "3.0.0-devnet.6-patch.1"
+  resolved "https://registry.yarnpkg.com/@aztec/accounts/-/accounts-3.0.0-devnet.6-patch.1.tgz#05b44647c732e3deb723571e73c10a36d762c154"
+  integrity sha512-0iJN0t6AYgv6rxYjLSQvbwo5n8zEfJdwHoydIkqSbSLbymU5NoDnNB7jwl1omAmWqBAKN4hOr4p8Gh2ZldYIsQ==
   dependencies:
-    "@aztec/aztec.js" "3.0.0-devnet.20251212"
-    "@aztec/entrypoints" "3.0.0-devnet.20251212"
-    "@aztec/ethereum" "3.0.0-devnet.20251212"
-    "@aztec/foundation" "3.0.0-devnet.20251212"
-    "@aztec/stdlib" "3.0.0-devnet.20251212"
+    "@aztec/aztec.js" "3.0.0-devnet.6-patch.1"
+    "@aztec/entrypoints" "3.0.0-devnet.6-patch.1"
+    "@aztec/ethereum" "3.0.0-devnet.6-patch.1"
+    "@aztec/foundation" "3.0.0-devnet.6-patch.1"
+    "@aztec/stdlib" "3.0.0-devnet.6-patch.1"
     tslib "^2.4.0"
 
-"@aztec/aztec.js@3.0.0-devnet.20251212":
-  version "3.0.0-devnet.20251212"
-  resolved "https://registry.yarnpkg.com/@aztec/aztec.js/-/aztec.js-3.0.0-devnet.20251212.tgz#8c84a5a60bf092360f6f80c6575b38c3dc41aa74"
-  integrity sha512-k0o3fZlDEf8XaBDFIhKIOgQES09/xOiCNnaaCBwfQgifPtxHKsdTnomXHVVwgJWD/gS7TtwLnNfvjYmEKy50cA==
+"@aztec/aztec.js@3.0.0-devnet.6-patch.1":
+  version "3.0.0-devnet.6-patch.1"
+  resolved "https://registry.yarnpkg.com/@aztec/aztec.js/-/aztec.js-3.0.0-devnet.6-patch.1.tgz#cbf2c015c76a7e346044cf6a0b7724f1a85d661f"
+  integrity sha512-vPba9qQg1IUyg9aTyzEJfHwtwb7guCF2BiBAwnqPKkhoSG06CoDHQfU7T+JqxY9QpdWqDGUSfvDCr5wRFlEL0g==
   dependencies:
-    "@aztec/constants" "3.0.0-devnet.20251212"
-    "@aztec/entrypoints" "3.0.0-devnet.20251212"
-    "@aztec/ethereum" "3.0.0-devnet.20251212"
-    "@aztec/foundation" "3.0.0-devnet.20251212"
-    "@aztec/l1-artifacts" "3.0.0-devnet.20251212"
-    "@aztec/protocol-contracts" "3.0.0-devnet.20251212"
-    "@aztec/stdlib" "3.0.0-devnet.20251212"
+    "@aztec/constants" "3.0.0-devnet.6-patch.1"
+    "@aztec/entrypoints" "3.0.0-devnet.6-patch.1"
+    "@aztec/ethereum" "3.0.0-devnet.6-patch.1"
+    "@aztec/foundation" "3.0.0-devnet.6-patch.1"
+    "@aztec/l1-artifacts" "3.0.0-devnet.6-patch.1"
+    "@aztec/protocol-contracts" "3.0.0-devnet.6-patch.1"
+    "@aztec/stdlib" "3.0.0-devnet.6-patch.1"
     axios "^1.12.0"
     tslib "^2.4.0"
     viem "npm:@aztec/viem@2.38.2"
     zod "^3.23.8"
 
-"@aztec/bb-prover@3.0.0-devnet.20251212":
-  version "3.0.0-devnet.20251212"
-  resolved "https://registry.yarnpkg.com/@aztec/bb-prover/-/bb-prover-3.0.0-devnet.20251212.tgz#86540c0272e910cbc35dffc97119dbf712521f94"
-  integrity sha512-wFb3yVIoZSCdcmcZTKBHsdzNtvt8S3nVhPFagoEL6ts8fJtrzYS1tYZ5mLukpwILkNJGnb+R+SLpaWEBnU7fTg==
+"@aztec/bb-prover@3.0.0-devnet.6-patch.1":
+  version "3.0.0-devnet.6-patch.1"
+  resolved "https://registry.yarnpkg.com/@aztec/bb-prover/-/bb-prover-3.0.0-devnet.6-patch.1.tgz#22155bbba2571eddf2cbc0cf0eccc3000224ce95"
+  integrity sha512-SMuVhCN6iA4WJOdk2Aj1iuK/+6I27cWCu0V/rm1ZQyNEryPteIXKnXleG5HWSZ+MRIngOAut+hT8cFhHRSfrLA==
   dependencies:
-    "@aztec/bb.js" "3.0.0-devnet.20251212"
-    "@aztec/constants" "3.0.0-devnet.20251212"
-    "@aztec/foundation" "3.0.0-devnet.20251212"
-    "@aztec/noir-noirc_abi" "3.0.0-devnet.20251212"
-    "@aztec/noir-protocol-circuits-types" "3.0.0-devnet.20251212"
-    "@aztec/noir-types" "3.0.0-devnet.20251212"
-    "@aztec/simulator" "3.0.0-devnet.20251212"
-    "@aztec/stdlib" "3.0.0-devnet.20251212"
-    "@aztec/telemetry-client" "3.0.0-devnet.20251212"
-    "@aztec/world-state" "3.0.0-devnet.20251212"
+    "@aztec/bb.js" "3.0.0-devnet.6-patch.1"
+    "@aztec/constants" "3.0.0-devnet.6-patch.1"
+    "@aztec/foundation" "3.0.0-devnet.6-patch.1"
+    "@aztec/noir-noirc_abi" "3.0.0-devnet.6-patch.1"
+    "@aztec/noir-protocol-circuits-types" "3.0.0-devnet.6-patch.1"
+    "@aztec/noir-types" "3.0.0-devnet.6-patch.1"
+    "@aztec/simulator" "3.0.0-devnet.6-patch.1"
+    "@aztec/stdlib" "3.0.0-devnet.6-patch.1"
+    "@aztec/telemetry-client" "3.0.0-devnet.6-patch.1"
+    "@aztec/world-state" "3.0.0-devnet.6-patch.1"
     commander "^12.1.0"
     pako "^2.1.0"
     source-map-support "^0.5.21"
     tslib "^2.4.0"
 
-"@aztec/bb.js@3.0.0-devnet.20251212":
-  version "3.0.0-devnet.20251212"
-  resolved "https://registry.yarnpkg.com/@aztec/bb.js/-/bb.js-3.0.0-devnet.20251212.tgz#cbf4c76db7b57f5515a0e1168b37200a9e91734b"
-  integrity sha512-9xqm3d9H9aDus8xGf7b7Bd9rkjYqp1PHHMmqNT8FJ/Rv5Pn/rJgwE+d4ZWJtm+inIIu8D8AeKTBc9bEEPjENUQ==
+"@aztec/bb.js@3.0.0-devnet.6-patch.1":
+  version "3.0.0-devnet.6-patch.1"
+  resolved "https://registry.yarnpkg.com/@aztec/bb.js/-/bb.js-3.0.0-devnet.6-patch.1.tgz#6781fa91d7faeb5a3bc1e3f8fabc4ddd4a9bb92c"
+  integrity sha512-ULRG/Ky5h2Lpaw4lXjkEzJdQVgfCFhBY9Fb0mL+Y+yC+thi2T5rQmmAwh5Qmr7F+KwKcozgtryV7Ook3rVjbhA==
   dependencies:
     comlink "^4.4.1"
     commander "^12.1.0"
@@ -636,54 +636,54 @@
     pako "^2.1.0"
     tslib "^2.4.0"
 
-"@aztec/blob-lib@3.0.0-devnet.20251212":
-  version "3.0.0-devnet.20251212"
-  resolved "https://registry.yarnpkg.com/@aztec/blob-lib/-/blob-lib-3.0.0-devnet.20251212.tgz#cc8f3e89b0078b761e46e6adbdf3e57e0480db4a"
-  integrity sha512-DiJBFkcPxuGBN51S6EaJfU+UxejcOwUzKFAIskPIHheb0kSFAad/4VVhhadtCudN72+iIBCExUtp7qBdJmePYQ==
+"@aztec/blob-lib@3.0.0-devnet.6-patch.1":
+  version "3.0.0-devnet.6-patch.1"
+  resolved "https://registry.yarnpkg.com/@aztec/blob-lib/-/blob-lib-3.0.0-devnet.6-patch.1.tgz#ca476037b413acbe75766785e5b26da09afe8c54"
+  integrity sha512-l3YxkxfAm3RF7016QHXFxlQF58wgSpI0u7xfe6NpupO7k3gnCOrLm8p6GcBGcIoTIcf5GJzK2QfZvBsX+WVZHw==
   dependencies:
-    "@aztec/constants" "3.0.0-devnet.20251212"
-    "@aztec/foundation" "3.0.0-devnet.20251212"
+    "@aztec/constants" "3.0.0-devnet.6-patch.1"
+    "@aztec/foundation" "3.0.0-devnet.6-patch.1"
     "@crate-crypto/node-eth-kzg" "^0.10.0"
     tslib "^2.4.0"
 
-"@aztec/builder@3.0.0-devnet.20251212":
-  version "3.0.0-devnet.20251212"
-  resolved "https://registry.yarnpkg.com/@aztec/builder/-/builder-3.0.0-devnet.20251212.tgz#1befe5bc1d0f10e87820fd775ad279589664360e"
-  integrity sha512-BUvWzdwUK7jnfpjsvdgbOpAvdZi3njH3MQHSIW3VYyEgUlVNT9NJtmCzY222vnBPeN4XLkNwBSaEe1DH+VuULw==
+"@aztec/builder@3.0.0-devnet.6-patch.1":
+  version "3.0.0-devnet.6-patch.1"
+  resolved "https://registry.yarnpkg.com/@aztec/builder/-/builder-3.0.0-devnet.6-patch.1.tgz#a25cd90e83e8c2595c6a3c0440c683e42e258af2"
+  integrity sha512-IPBXJVhDu3T3K59uVCBX/jK+/Wkn5Z0coBzlcRQkr6puLv8sZod8vPwPrEGeWxOYz6VZN7JUkJup5ZqKR2vFgg==
   dependencies:
-    "@aztec/foundation" "3.0.0-devnet.20251212"
-    "@aztec/stdlib" "3.0.0-devnet.20251212"
+    "@aztec/foundation" "3.0.0-devnet.6-patch.1"
+    "@aztec/stdlib" "3.0.0-devnet.6-patch.1"
     commander "^12.1.0"
 
-"@aztec/constants@3.0.0-devnet.20251212":
-  version "3.0.0-devnet.20251212"
-  resolved "https://registry.yarnpkg.com/@aztec/constants/-/constants-3.0.0-devnet.20251212.tgz#2960ebfea2852313c76af6b967c53958e03006cb"
-  integrity sha512-R0pYLhWUnDago/MO8+iuG/2yrP4yVDZuQvOmXwDqp5ed+SR4zj8sqvC52paXrOxhcLpheVpEHp2TuGKtmssvtg==
+"@aztec/constants@3.0.0-devnet.6-patch.1":
+  version "3.0.0-devnet.6-patch.1"
+  resolved "https://registry.yarnpkg.com/@aztec/constants/-/constants-3.0.0-devnet.6-patch.1.tgz#c0588e4039de977949b997cb65f45721539cf6bd"
+  integrity sha512-YKH/JQ+Qpd8X9xtWwTBc1yVChjfO9yKFPH2x/LIll89rkPT9GU3OKQeKpnXOKlnC/2IWW2ZExASfwttp8TWtXg==
   dependencies:
-    "@aztec/foundation" "3.0.0-devnet.20251212"
+    "@aztec/foundation" "3.0.0-devnet.6-patch.1"
     tslib "^2.4.0"
 
-"@aztec/entrypoints@3.0.0-devnet.20251212":
-  version "3.0.0-devnet.20251212"
-  resolved "https://registry.yarnpkg.com/@aztec/entrypoints/-/entrypoints-3.0.0-devnet.20251212.tgz#a67151a3d9c078b91bf8e3869cddd64c784eaab5"
-  integrity sha512-XlMkUqetlM1lzVycxmIdQ1FtM2kfFtKU+7GG01mGnhawFHJnBT8EqMQjxaSKCO9fQYTNIl1oUELhyzpiWL/ztg==
+"@aztec/entrypoints@3.0.0-devnet.6-patch.1":
+  version "3.0.0-devnet.6-patch.1"
+  resolved "https://registry.yarnpkg.com/@aztec/entrypoints/-/entrypoints-3.0.0-devnet.6-patch.1.tgz#ade9929ab6351c990844649b62a2ccc7ce474400"
+  integrity sha512-rHVRJGk7rxw16rxxQzfojnYjqK0zBtQVghLj1+4p91looN0T4xS8sEXr4jCGPG78uj3NLkYLuPQCQCDVmWXVcA==
   dependencies:
-    "@aztec/constants" "3.0.0-devnet.20251212"
-    "@aztec/foundation" "3.0.0-devnet.20251212"
-    "@aztec/protocol-contracts" "3.0.0-devnet.20251212"
-    "@aztec/stdlib" "3.0.0-devnet.20251212"
+    "@aztec/constants" "3.0.0-devnet.6-patch.1"
+    "@aztec/foundation" "3.0.0-devnet.6-patch.1"
+    "@aztec/protocol-contracts" "3.0.0-devnet.6-patch.1"
+    "@aztec/stdlib" "3.0.0-devnet.6-patch.1"
     tslib "^2.4.0"
     zod "^3.23.8"
 
-"@aztec/ethereum@3.0.0-devnet.20251212":
-  version "3.0.0-devnet.20251212"
-  resolved "https://registry.yarnpkg.com/@aztec/ethereum/-/ethereum-3.0.0-devnet.20251212.tgz#910f811f04c319edbde9d1af192b8753936061ba"
-  integrity sha512-smAL13K73bpP5SXDYoYukQsnOa6iHC7a1HP1tf3Llk9mF0hS1BXV+kyrltiVeVHSN5/UkZN4WZ50yQ5CCeq6rg==
+"@aztec/ethereum@3.0.0-devnet.6-patch.1":
+  version "3.0.0-devnet.6-patch.1"
+  resolved "https://registry.yarnpkg.com/@aztec/ethereum/-/ethereum-3.0.0-devnet.6-patch.1.tgz#16a1f80facf54441b4f606d01fa0a83103f6d74f"
+  integrity sha512-J1QxJFpYIcWw3Se8eVBWMTvZsGTngwz7h6wgWEkUj2noFe2zPpvASGe389rrHPqqdsQ70yZ92kDaHQ2KyhDzLw==
   dependencies:
-    "@aztec/blob-lib" "3.0.0-devnet.20251212"
-    "@aztec/constants" "3.0.0-devnet.20251212"
-    "@aztec/foundation" "3.0.0-devnet.20251212"
-    "@aztec/l1-artifacts" "3.0.0-devnet.20251212"
+    "@aztec/blob-lib" "3.0.0-devnet.6-patch.1"
+    "@aztec/constants" "3.0.0-devnet.6-patch.1"
+    "@aztec/foundation" "3.0.0-devnet.6-patch.1"
+    "@aztec/l1-artifacts" "3.0.0-devnet.6-patch.1"
     "@viem/anvil" "^0.0.10"
     dotenv "^16.0.3"
     lodash.chunk "^4.2.0"
@@ -692,12 +692,12 @@
     viem "npm:@aztec/viem@2.38.2"
     zod "^3.23.8"
 
-"@aztec/foundation@3.0.0-devnet.20251212":
-  version "3.0.0-devnet.20251212"
-  resolved "https://registry.yarnpkg.com/@aztec/foundation/-/foundation-3.0.0-devnet.20251212.tgz#2871a76946ee051b7a42cbf9c9defa08220ea054"
-  integrity sha512-1yBGAJCO4VjmaZTx5qbJ2vW8yjWlLae524L08zOSGoEqF2RIkCvbQyIOaH/ZWb5n866LP66XhUfoaohPmgK+EA==
+"@aztec/foundation@3.0.0-devnet.6-patch.1":
+  version "3.0.0-devnet.6-patch.1"
+  resolved "https://registry.yarnpkg.com/@aztec/foundation/-/foundation-3.0.0-devnet.6-patch.1.tgz#feacdef89029695ccec0fa7d419faf595d5ab27a"
+  integrity sha512-8oNaZPdU0vMRPxHZzwkOfEPsC9IRswP1WXCqxgdQHYSufYNxNrDZ7aVQpuI0sPkA3BsCXzPb/tQTgD+E2WoYEQ==
   dependencies:
-    "@aztec/bb.js" "3.0.0-devnet.20251212"
+    "@aztec/bb.js" "3.0.0-devnet.6-patch.1"
     "@koa/cors" "^5.0.0"
     "@noble/curves" "=1.7.0"
     "@noble/hashes" "^1.6.1"
@@ -720,140 +720,140 @@
     undici "^5.28.5"
     zod "^3.23.8"
 
-"@aztec/key-store@3.0.0-devnet.20251212":
-  version "3.0.0-devnet.20251212"
-  resolved "https://registry.yarnpkg.com/@aztec/key-store/-/key-store-3.0.0-devnet.20251212.tgz#0d0bf89969a8e8a5f1f0db86d1f1cd703478af19"
-  integrity sha512-FMh8hsXZNMMz+DHDdKgTyeNfdH0FHiwQygDdi3n2rRr0Io7Jc3HMPqB3w5dFt8qKxTelNmFqll5XRu5IZDuAvg==
+"@aztec/key-store@3.0.0-devnet.6-patch.1":
+  version "3.0.0-devnet.6-patch.1"
+  resolved "https://registry.yarnpkg.com/@aztec/key-store/-/key-store-3.0.0-devnet.6-patch.1.tgz#962c91aa606131a6e38ab2845049bd07d7e46781"
+  integrity sha512-LV3JhRG0RW5O4CK5dB4MEOQQHM+N6HwHeQrJG9tZr5P52GzwT7PlBPmopzuq/iKIh48MNizfMTux5681UqBe2Q==
   dependencies:
-    "@aztec/constants" "3.0.0-devnet.20251212"
-    "@aztec/foundation" "3.0.0-devnet.20251212"
-    "@aztec/kv-store" "3.0.0-devnet.20251212"
-    "@aztec/stdlib" "3.0.0-devnet.20251212"
+    "@aztec/constants" "3.0.0-devnet.6-patch.1"
+    "@aztec/foundation" "3.0.0-devnet.6-patch.1"
+    "@aztec/kv-store" "3.0.0-devnet.6-patch.1"
+    "@aztec/stdlib" "3.0.0-devnet.6-patch.1"
     tslib "^2.4.0"
 
-"@aztec/kv-store@3.0.0-devnet.20251212":
-  version "3.0.0-devnet.20251212"
-  resolved "https://registry.yarnpkg.com/@aztec/kv-store/-/kv-store-3.0.0-devnet.20251212.tgz#6199beb780558a180200f9cc1b246fd7df009af1"
-  integrity sha512-Qe1aYRpQFHFwsvtNKLHphKNYxEB4vIOSqqgFME8oYw3nsq2AlV/Byrmw0x3jXVc15QLc6x8uTn1rXqpZK+u3tA==
+"@aztec/kv-store@3.0.0-devnet.6-patch.1":
+  version "3.0.0-devnet.6-patch.1"
+  resolved "https://registry.yarnpkg.com/@aztec/kv-store/-/kv-store-3.0.0-devnet.6-patch.1.tgz#19850f5423a7d45d59656a50e57bad478599fe2c"
+  integrity sha512-Y3hMLidonMlN3eC/Blc+o6dN9VY+byLJsPXvNu+snGc6QR8rPw2x+vM/+QInsx9AFoIRfDjZU+64QMLKS4bizw==
   dependencies:
-    "@aztec/constants" "3.0.0-devnet.20251212"
-    "@aztec/ethereum" "3.0.0-devnet.20251212"
-    "@aztec/foundation" "3.0.0-devnet.20251212"
-    "@aztec/native" "3.0.0-devnet.20251212"
-    "@aztec/stdlib" "3.0.0-devnet.20251212"
+    "@aztec/constants" "3.0.0-devnet.6-patch.1"
+    "@aztec/ethereum" "3.0.0-devnet.6-patch.1"
+    "@aztec/foundation" "3.0.0-devnet.6-patch.1"
+    "@aztec/native" "3.0.0-devnet.6-patch.1"
+    "@aztec/stdlib" "3.0.0-devnet.6-patch.1"
     idb "^8.0.0"
     lmdb "^3.2.0"
     msgpackr "^1.11.2"
     ohash "^2.0.11"
     ordered-binary "^1.5.3"
 
-"@aztec/l1-artifacts@3.0.0-devnet.20251212":
-  version "3.0.0-devnet.20251212"
-  resolved "https://registry.yarnpkg.com/@aztec/l1-artifacts/-/l1-artifacts-3.0.0-devnet.20251212.tgz#431713cd66794eb8d890f0f379a55809a7822e61"
-  integrity sha512-IGWQ8ie2W1Ok8bLnfmuvazULT9dPj9ozYDujcgI+lWYnUbTDR5ja7tfx9qG//9Um+FFKZL5JErm0qtsPSrO2tg==
+"@aztec/l1-artifacts@3.0.0-devnet.6-patch.1":
+  version "3.0.0-devnet.6-patch.1"
+  resolved "https://registry.yarnpkg.com/@aztec/l1-artifacts/-/l1-artifacts-3.0.0-devnet.6-patch.1.tgz#fb017bcf65cfa9a9610b64ad0dcc7ff4fd46b0b2"
+  integrity sha512-aO01TaullALg6Mn/GK/HgB9AB+8mxyrQi7X9It/i2u+SA8UiIQuwoBzr3uAA1hsWnRCSD+M7RikMBvVmVDlYkg==
   dependencies:
     tslib "^2.4.0"
 
-"@aztec/merkle-tree@3.0.0-devnet.20251212":
-  version "3.0.0-devnet.20251212"
-  resolved "https://registry.yarnpkg.com/@aztec/merkle-tree/-/merkle-tree-3.0.0-devnet.20251212.tgz#f9ecfd673d0639f9629906e5610fbe5e06dff824"
-  integrity sha512-uXJm69QJElxnnPah7JSynsw7+xaVzIOWFxqYLP9QgQG7M1MyYE9WQyK78LMRUb8iG3sW84udFcvdSuCMwL1YEw==
+"@aztec/merkle-tree@3.0.0-devnet.6-patch.1":
+  version "3.0.0-devnet.6-patch.1"
+  resolved "https://registry.yarnpkg.com/@aztec/merkle-tree/-/merkle-tree-3.0.0-devnet.6-patch.1.tgz#df973c1eea7ff561fc6b6545575df7813d32f10e"
+  integrity sha512-u6jt+4ATePLnCzACe1VGNYEjbRKDj19xgLtVa+nzcBBO527UIueKxQxjPZ8j9yMcLPGrSvDTdBqaOdm7uWPI4Q==
   dependencies:
-    "@aztec/foundation" "3.0.0-devnet.20251212"
-    "@aztec/kv-store" "3.0.0-devnet.20251212"
-    "@aztec/stdlib" "3.0.0-devnet.20251212"
+    "@aztec/foundation" "3.0.0-devnet.6-patch.1"
+    "@aztec/kv-store" "3.0.0-devnet.6-patch.1"
+    "@aztec/stdlib" "3.0.0-devnet.6-patch.1"
     sha256 "^0.2.0"
     tslib "^2.4.0"
 
-"@aztec/native@3.0.0-devnet.20251212":
-  version "3.0.0-devnet.20251212"
-  resolved "https://registry.yarnpkg.com/@aztec/native/-/native-3.0.0-devnet.20251212.tgz#eaaecdbacee3295077219de400b8eafa4c8c5e8a"
-  integrity sha512-UIUjQRK2S54Pr0tZinUek7rjtfh0fZbdxJFzEFTBElO/g5rExK8FUX8S1Fz3DfFOJNgBj9Y8RW2oj3yZEKxTvw==
+"@aztec/native@3.0.0-devnet.6-patch.1":
+  version "3.0.0-devnet.6-patch.1"
+  resolved "https://registry.yarnpkg.com/@aztec/native/-/native-3.0.0-devnet.6-patch.1.tgz#601c5bac626ea5fd60d45820205ec4b54c67f9c8"
+  integrity sha512-UNTdTD/sKJFzCjFjUcpX3g1ElxyIIDkkaMJek6CCb1rsXVtALgIx6K7QhRq26hkUPgS0pBpFPgznFOvh1bsE8w==
   dependencies:
-    "@aztec/bb.js" "3.0.0-devnet.20251212"
-    "@aztec/foundation" "3.0.0-devnet.20251212"
+    "@aztec/bb.js" "3.0.0-devnet.6-patch.1"
+    "@aztec/foundation" "3.0.0-devnet.6-patch.1"
     msgpackr "^1.11.2"
 
-"@aztec/noir-acvm_js@3.0.0-devnet.20251212":
-  version "3.0.0-devnet.20251212"
-  resolved "https://registry.yarnpkg.com/@aztec/noir-acvm_js/-/noir-acvm_js-3.0.0-devnet.20251212.tgz#efe93e644afed661fe6d5b17f4fd5cc273fa4e21"
-  integrity sha512-vQujIYW0urROyi/+REygX1YyHuHSBMSFyOc2P7pyFEILmlMH8ZLyLjtUWHm8bUa8gq8G+zsd7Bn2p+MEiBhMtg==
+"@aztec/noir-acvm_js@3.0.0-devnet.6-patch.1":
+  version "3.0.0-devnet.6-patch.1"
+  resolved "https://registry.yarnpkg.com/@aztec/noir-acvm_js/-/noir-acvm_js-3.0.0-devnet.6-patch.1.tgz#c6930c121c2a186cb7a071d46ff59b1ddda97da0"
+  integrity sha512-gJTPvM2bDzj+sVH5gmWgBo0tNyaecWyXmYwZCP4Cz5DtwfN7bcT4JAmjLex0u85i6rpJ+ij9ayPB8msqhvLJSw==
 
-"@aztec/noir-contracts.js@3.0.0-devnet.20251212":
-  version "3.0.0-devnet.20251212"
-  resolved "https://registry.yarnpkg.com/@aztec/noir-contracts.js/-/noir-contracts.js-3.0.0-devnet.20251212.tgz#91602e1ab1b517a12ebb90c868c1bd22d706c34d"
-  integrity sha512-+Jl3za8TTK9VkiDitj6cMCdpmD0A3buvafoVNPmTUU8AvO1YMTrs6OPDvMEXKVpmwRZI6zOCPF+0H1u9zDW5BA==
+"@aztec/noir-contracts.js@3.0.0-devnet.6-patch.1":
+  version "3.0.0-devnet.6-patch.1"
+  resolved "https://registry.yarnpkg.com/@aztec/noir-contracts.js/-/noir-contracts.js-3.0.0-devnet.6-patch.1.tgz#b9fdfec34de536ae579e3481177a046c27bf3598"
+  integrity sha512-GP1VX+qm5bkSsGpeekCWaLOAoMPFqpckx/WIqAyxJLlSTS7QuvANEulGJI22IBhktu133CtXXfzjATHPEGbN4g==
   dependencies:
-    "@aztec/aztec.js" "3.0.0-devnet.20251212"
+    "@aztec/aztec.js" "3.0.0-devnet.6-patch.1"
     tslib "^2.4.0"
 
-"@aztec/noir-noir_codegen@3.0.0-devnet.20251212":
-  version "3.0.0-devnet.20251212"
-  resolved "https://registry.yarnpkg.com/@aztec/noir-noir_codegen/-/noir-noir_codegen-3.0.0-devnet.20251212.tgz#8a278ca2f2e3e5c524047b96166ebe987dba00d0"
-  integrity sha512-yl1+tmypfKODxsq6PxPsCjRJokI3S+rU6gNvO6XLQTRuFkDIDfp4qDoevD9VnZvjtkataS2z99AylsJdxFToEQ==
+"@aztec/noir-noir_codegen@3.0.0-devnet.6-patch.1":
+  version "3.0.0-devnet.6-patch.1"
+  resolved "https://registry.yarnpkg.com/@aztec/noir-noir_codegen/-/noir-noir_codegen-3.0.0-devnet.6-patch.1.tgz#d7d614cb2cb828766977298076d8c3c48da95e16"
+  integrity sha512-dTvCSdNhSavN5vQ4rBZjD5A2mTgwnRXlNM4wOfJgk1bZEeuapJpD1bc98nV5e4a8C/G0TRgQT7CaxbrHluDdpw==
   dependencies:
-    "@aztec/noir-types" "3.0.0-devnet.20251212"
+    "@aztec/noir-types" "3.0.0-devnet.6-patch.1"
     glob "^11.0.3"
     ts-command-line-args "^2.5.1"
 
-"@aztec/noir-noirc_abi@3.0.0-devnet.20251212":
-  version "3.0.0-devnet.20251212"
-  resolved "https://registry.yarnpkg.com/@aztec/noir-noirc_abi/-/noir-noirc_abi-3.0.0-devnet.20251212.tgz#368242d4b23f3627086e00588bb34573fba69b46"
-  integrity sha512-HuABbS7Cr4xXFQ3Fqq86hoDzbAnxe7iXJK6Oow6Ak8PqNu1kdvZpwLLMpDvTE/1sCio+lEbnNmxpp5ko2yckSQ==
+"@aztec/noir-noirc_abi@3.0.0-devnet.6-patch.1":
+  version "3.0.0-devnet.6-patch.1"
+  resolved "https://registry.yarnpkg.com/@aztec/noir-noirc_abi/-/noir-noirc_abi-3.0.0-devnet.6-patch.1.tgz#9cc1a1ebbce77f74a9c08d587c9363bd28c99b36"
+  integrity sha512-+J9StgFWBSi+zhGTmXXNbe3LV3lJ7FC4nmwQP6VENVLzoo1icT6S77N0xrfbcHCbdqmzw8FtKz0BR69VuXdChQ==
   dependencies:
-    "@aztec/noir-types" "3.0.0-devnet.20251212"
+    "@aztec/noir-types" "3.0.0-devnet.6-patch.1"
 
-"@aztec/noir-protocol-circuits-types@3.0.0-devnet.20251212":
-  version "3.0.0-devnet.20251212"
-  resolved "https://registry.yarnpkg.com/@aztec/noir-protocol-circuits-types/-/noir-protocol-circuits-types-3.0.0-devnet.20251212.tgz#174eadaaba675393983609a5a5683d0e69912075"
-  integrity sha512-gBz5UbR1QV5bmg/6y+an77GEJmM2ed1/UCtJwGmbRjhA6Bq+l8ghTphAFtO2eOs/OOp6vaEOBWBCEvTUpF/j0w==
+"@aztec/noir-protocol-circuits-types@3.0.0-devnet.6-patch.1":
+  version "3.0.0-devnet.6-patch.1"
+  resolved "https://registry.yarnpkg.com/@aztec/noir-protocol-circuits-types/-/noir-protocol-circuits-types-3.0.0-devnet.6-patch.1.tgz#1abd030097cb9540d4bee70d8d133a3c5a587945"
+  integrity sha512-/e8nlQjsZIE1OKE53zlH8EJUkw24/IEZ3Zsj4HNoSQvKz63Zu0yoNrTst02owUYqTprrDuFj5YL8qouTo3UsXA==
   dependencies:
-    "@aztec/blob-lib" "3.0.0-devnet.20251212"
-    "@aztec/constants" "3.0.0-devnet.20251212"
-    "@aztec/foundation" "3.0.0-devnet.20251212"
-    "@aztec/noir-acvm_js" "3.0.0-devnet.20251212"
-    "@aztec/noir-noir_codegen" "3.0.0-devnet.20251212"
-    "@aztec/noir-noirc_abi" "3.0.0-devnet.20251212"
-    "@aztec/noir-types" "3.0.0-devnet.20251212"
-    "@aztec/stdlib" "3.0.0-devnet.20251212"
+    "@aztec/blob-lib" "3.0.0-devnet.6-patch.1"
+    "@aztec/constants" "3.0.0-devnet.6-patch.1"
+    "@aztec/foundation" "3.0.0-devnet.6-patch.1"
+    "@aztec/noir-acvm_js" "3.0.0-devnet.6-patch.1"
+    "@aztec/noir-noir_codegen" "3.0.0-devnet.6-patch.1"
+    "@aztec/noir-noirc_abi" "3.0.0-devnet.6-patch.1"
+    "@aztec/noir-types" "3.0.0-devnet.6-patch.1"
+    "@aztec/stdlib" "3.0.0-devnet.6-patch.1"
     change-case "^5.4.4"
     tslib "^2.4.0"
 
-"@aztec/noir-types@3.0.0-devnet.20251212":
-  version "3.0.0-devnet.20251212"
-  resolved "https://registry.yarnpkg.com/@aztec/noir-types/-/noir-types-3.0.0-devnet.20251212.tgz#878793c148d4305e0113963fdbdd4a4791fca01e"
-  integrity sha512-cFgkHsupyJmDkN/MEP7EDgG9pBKO4jGNH9Y3d3t0OIhRjlberBRv0HtlcfTfaKeM2DZ2x/Lloov+5J6mfuyMrA==
+"@aztec/noir-types@3.0.0-devnet.6-patch.1":
+  version "3.0.0-devnet.6-patch.1"
+  resolved "https://registry.yarnpkg.com/@aztec/noir-types/-/noir-types-3.0.0-devnet.6-patch.1.tgz#ce91b70427983bf32bb013d6c86b0b2e348956c3"
+  integrity sha512-zj7/ERBvTcnypoytwk4RBiN4mBe1kRVZJpd9byUPc5p9vVqi2uYkbaLa1JpjwyKShItWXU6TXv6C8V23jj5mGA==
 
-"@aztec/protocol-contracts@3.0.0-devnet.20251212":
-  version "3.0.0-devnet.20251212"
-  resolved "https://registry.yarnpkg.com/@aztec/protocol-contracts/-/protocol-contracts-3.0.0-devnet.20251212.tgz#d08620926a4370995b58a2ba4341a8324d82b8ab"
-  integrity sha512-AZSTimslrwiyc4d3doifGQcUmayuYDZkD+Eo/U9udIz4uexljVgOVCNMbciDbDGDuEkKEd6mg/W/YlAcTqCdqQ==
+"@aztec/protocol-contracts@3.0.0-devnet.6-patch.1":
+  version "3.0.0-devnet.6-patch.1"
+  resolved "https://registry.yarnpkg.com/@aztec/protocol-contracts/-/protocol-contracts-3.0.0-devnet.6-patch.1.tgz#b5a79b19041593744d776a0adb9c0e1f99d50ca7"
+  integrity sha512-QbpoSNLZ54xzAmeen3t+oJEKoeoqD84mrP+ooFgLNPwuXAU48BP5Otq3aZIycIfTcjXnjIhORzLURX0ftU3sKg==
   dependencies:
-    "@aztec/constants" "3.0.0-devnet.20251212"
-    "@aztec/foundation" "3.0.0-devnet.20251212"
-    "@aztec/stdlib" "3.0.0-devnet.20251212"
+    "@aztec/constants" "3.0.0-devnet.6-patch.1"
+    "@aztec/foundation" "3.0.0-devnet.6-patch.1"
+    "@aztec/stdlib" "3.0.0-devnet.6-patch.1"
     lodash.chunk "^4.2.0"
     lodash.omit "^4.5.0"
     tslib "^2.4.0"
 
-"@aztec/pxe@3.0.0-devnet.20251212":
-  version "3.0.0-devnet.20251212"
-  resolved "https://registry.yarnpkg.com/@aztec/pxe/-/pxe-3.0.0-devnet.20251212.tgz#dd9916163a41ed1c8532768ac8f92fa1e2426468"
-  integrity sha512-wmg2emJsutWNnHCuly+2t/C43PFEtGqoHzkCSsDhfgWDgjtaScROyaGoCHyNjqGDJvhfe5HQ+cfGjjEuYia0Qw==
+"@aztec/pxe@3.0.0-devnet.6-patch.1":
+  version "3.0.0-devnet.6-patch.1"
+  resolved "https://registry.yarnpkg.com/@aztec/pxe/-/pxe-3.0.0-devnet.6-patch.1.tgz#996f07b034f8f97a254ed4d5bc8814e339f9e709"
+  integrity sha512-ugKffEjNH+U6EfkVuXceozQhmbHgCtLmNx2Jxl02hzW44/41lmL05zAHXCL5IKi+5NfyaRmMjxFJ898jXKa8Lw==
   dependencies:
-    "@aztec/bb-prover" "3.0.0-devnet.20251212"
-    "@aztec/bb.js" "3.0.0-devnet.20251212"
-    "@aztec/builder" "3.0.0-devnet.20251212"
-    "@aztec/constants" "3.0.0-devnet.20251212"
-    "@aztec/ethereum" "3.0.0-devnet.20251212"
-    "@aztec/foundation" "3.0.0-devnet.20251212"
-    "@aztec/key-store" "3.0.0-devnet.20251212"
-    "@aztec/kv-store" "3.0.0-devnet.20251212"
-    "@aztec/noir-protocol-circuits-types" "3.0.0-devnet.20251212"
-    "@aztec/noir-types" "3.0.0-devnet.20251212"
-    "@aztec/protocol-contracts" "3.0.0-devnet.20251212"
-    "@aztec/simulator" "3.0.0-devnet.20251212"
-    "@aztec/stdlib" "3.0.0-devnet.20251212"
+    "@aztec/bb-prover" "3.0.0-devnet.6-patch.1"
+    "@aztec/bb.js" "3.0.0-devnet.6-patch.1"
+    "@aztec/builder" "3.0.0-devnet.6-patch.1"
+    "@aztec/constants" "3.0.0-devnet.6-patch.1"
+    "@aztec/ethereum" "3.0.0-devnet.6-patch.1"
+    "@aztec/foundation" "3.0.0-devnet.6-patch.1"
+    "@aztec/key-store" "3.0.0-devnet.6-patch.1"
+    "@aztec/kv-store" "3.0.0-devnet.6-patch.1"
+    "@aztec/noir-protocol-circuits-types" "3.0.0-devnet.6-patch.1"
+    "@aztec/noir-types" "3.0.0-devnet.6-patch.1"
+    "@aztec/protocol-contracts" "3.0.0-devnet.6-patch.1"
+    "@aztec/simulator" "3.0.0-devnet.6-patch.1"
+    "@aztec/stdlib" "3.0.0-devnet.6-patch.1"
     koa "^2.16.1"
     koa-router "^13.1.1"
     lodash.omit "^4.5.0"
@@ -861,39 +861,39 @@
     tslib "^2.4.0"
     viem "npm:@aztec/viem@2.38.2"
 
-"@aztec/simulator@3.0.0-devnet.20251212":
-  version "3.0.0-devnet.20251212"
-  resolved "https://registry.yarnpkg.com/@aztec/simulator/-/simulator-3.0.0-devnet.20251212.tgz#da2f87175593acbb6a830c99a7e4a0992d3897b7"
-  integrity sha512-juVBLvDEMBPkzg6gaxtRGeuBiPq35S1BEI1L5Y1z1GHZXvrPxR/R8Q2YrG8wBgdNvfPtXCFXDlW1FF2AFtORtA==
+"@aztec/simulator@3.0.0-devnet.6-patch.1":
+  version "3.0.0-devnet.6-patch.1"
+  resolved "https://registry.yarnpkg.com/@aztec/simulator/-/simulator-3.0.0-devnet.6-patch.1.tgz#0c22af0f6be531c8b32b0f735a3e8ae207530cb7"
+  integrity sha512-nDXLLCYMDVTCi8uUUBGO715f4Q+KyoKPa8p0bpJ/08y99aPT67BoouUJE0XXAv44MbQcLgt1SO0dwdW9Cc81Tg==
   dependencies:
-    "@aztec/constants" "3.0.0-devnet.20251212"
-    "@aztec/foundation" "3.0.0-devnet.20251212"
-    "@aztec/native" "3.0.0-devnet.20251212"
-    "@aztec/noir-acvm_js" "3.0.0-devnet.20251212"
-    "@aztec/noir-noirc_abi" "3.0.0-devnet.20251212"
-    "@aztec/noir-protocol-circuits-types" "3.0.0-devnet.20251212"
-    "@aztec/noir-types" "3.0.0-devnet.20251212"
-    "@aztec/protocol-contracts" "3.0.0-devnet.20251212"
-    "@aztec/stdlib" "3.0.0-devnet.20251212"
-    "@aztec/telemetry-client" "3.0.0-devnet.20251212"
-    "@aztec/world-state" "3.0.0-devnet.20251212"
+    "@aztec/constants" "3.0.0-devnet.6-patch.1"
+    "@aztec/foundation" "3.0.0-devnet.6-patch.1"
+    "@aztec/native" "3.0.0-devnet.6-patch.1"
+    "@aztec/noir-acvm_js" "3.0.0-devnet.6-patch.1"
+    "@aztec/noir-noirc_abi" "3.0.0-devnet.6-patch.1"
+    "@aztec/noir-protocol-circuits-types" "3.0.0-devnet.6-patch.1"
+    "@aztec/noir-types" "3.0.0-devnet.6-patch.1"
+    "@aztec/protocol-contracts" "3.0.0-devnet.6-patch.1"
+    "@aztec/stdlib" "3.0.0-devnet.6-patch.1"
+    "@aztec/telemetry-client" "3.0.0-devnet.6-patch.1"
+    "@aztec/world-state" "3.0.0-devnet.6-patch.1"
     lodash.clonedeep "^4.5.0"
     lodash.merge "^4.6.2"
     tslib "^2.4.0"
 
-"@aztec/stdlib@3.0.0-devnet.20251212":
-  version "3.0.0-devnet.20251212"
-  resolved "https://registry.yarnpkg.com/@aztec/stdlib/-/stdlib-3.0.0-devnet.20251212.tgz#e87ea64a15137aaa55395f30278ba184a3928f97"
-  integrity sha512-dynBZhet96Uq4xXM4oqRUcD/7E6pJXK3yVQH5cpCUEzk47vzDeQCdbRiIJJ+QEM5SVIjx2PG0fct1nFXcCD5Hw==
+"@aztec/stdlib@3.0.0-devnet.6-patch.1":
+  version "3.0.0-devnet.6-patch.1"
+  resolved "https://registry.yarnpkg.com/@aztec/stdlib/-/stdlib-3.0.0-devnet.6-patch.1.tgz#0f82be8011843165519293f11e9ec9c43bc86a5f"
+  integrity sha512-nljgFQ046BKWg10HTiYD/UjrC8rWs+8nRFWMVeAPrLiX0mWrjjMHkqag480U2ROO4YpdqqgbVujnNmQa/cLzuA==
   dependencies:
     "@aws-sdk/client-s3" "^3.892.0"
-    "@aztec/bb.js" "3.0.0-devnet.20251212"
-    "@aztec/blob-lib" "3.0.0-devnet.20251212"
-    "@aztec/constants" "3.0.0-devnet.20251212"
-    "@aztec/ethereum" "3.0.0-devnet.20251212"
-    "@aztec/foundation" "3.0.0-devnet.20251212"
-    "@aztec/l1-artifacts" "3.0.0-devnet.20251212"
-    "@aztec/noir-noirc_abi" "3.0.0-devnet.20251212"
+    "@aztec/bb.js" "3.0.0-devnet.6-patch.1"
+    "@aztec/blob-lib" "3.0.0-devnet.6-patch.1"
+    "@aztec/constants" "3.0.0-devnet.6-patch.1"
+    "@aztec/ethereum" "3.0.0-devnet.6-patch.1"
+    "@aztec/foundation" "3.0.0-devnet.6-patch.1"
+    "@aztec/l1-artifacts" "3.0.0-devnet.6-patch.1"
+    "@aztec/noir-noirc_abi" "3.0.0-devnet.6-patch.1"
     "@google-cloud/storage" "^7.15.0"
     axios "^1.12.0"
     json-stringify-deterministic "1.0.12"
@@ -907,13 +907,13 @@
     viem "npm:@aztec/viem@2.38.2"
     zod "^3.23.8"
 
-"@aztec/telemetry-client@3.0.0-devnet.20251212":
-  version "3.0.0-devnet.20251212"
-  resolved "https://registry.yarnpkg.com/@aztec/telemetry-client/-/telemetry-client-3.0.0-devnet.20251212.tgz#7cef701d20f1adcdde6508c1dc101a638e830db0"
-  integrity sha512-Q77CD74Y+aCiisqdXvitYF31/3N5No5CKSf5w/DsL5WKpyiIsW0fEM09QBIhEz3JUCh9J7jG4cz7PaNQ5xoyQg==
+"@aztec/telemetry-client@3.0.0-devnet.6-patch.1":
+  version "3.0.0-devnet.6-patch.1"
+  resolved "https://registry.yarnpkg.com/@aztec/telemetry-client/-/telemetry-client-3.0.0-devnet.6-patch.1.tgz#599032472c50ffe1d45641e9568ff1cae99c46b0"
+  integrity sha512-XZeLKSf2ws+2VEzGDESBkFo8kI9BGNTRXHpAJZ7NIFCbEGBwb44N0Rf8S8BBJgixARg7iUaiiFs2y2mBf3b2Gg==
   dependencies:
-    "@aztec/foundation" "3.0.0-devnet.20251212"
-    "@aztec/stdlib" "3.0.0-devnet.20251212"
+    "@aztec/foundation" "3.0.0-devnet.6-patch.1"
+    "@aztec/stdlib" "3.0.0-devnet.6-patch.1"
     "@opentelemetry/api" "^1.9.0"
     "@opentelemetry/api-logs" "^0.55.0"
     "@opentelemetry/core" "^1.28.0"
@@ -931,45 +931,45 @@
     prom-client "^15.1.3"
     viem "npm:@aztec/viem@2.38.2"
 
-"@aztec/test-wallet@3.0.0-devnet.20251212":
-  version "3.0.0-devnet.20251212"
-  resolved "https://registry.yarnpkg.com/@aztec/test-wallet/-/test-wallet-3.0.0-devnet.20251212.tgz#b72ec3502dc7361850a94c25684f167afa6a6322"
-  integrity sha512-f2rqo8YPOtPrDsPnjYFdYb8bg1uWYAQvtN+jYYTKT9m2EuqJ8e9urXbifG2Qpa4WkLzycYFbhO/lwwwnJ8OD8A==
+"@aztec/test-wallet@3.0.0-devnet.6-patch.1":
+  version "3.0.0-devnet.6-patch.1"
+  resolved "https://registry.yarnpkg.com/@aztec/test-wallet/-/test-wallet-3.0.0-devnet.6-patch.1.tgz#fc70b9c639ed77d1a04d449f2aaf36f5bfeee784"
+  integrity sha512-K9jZrWN2XKzLm9X3prLwuvNPFKf9q+jc6jnuesHAMDsLDMDjG5YYBlLfYYHsNI6DbpHT0CxGDgPFuK4qYB3Dqg==
   dependencies:
-    "@aztec/accounts" "3.0.0-devnet.20251212"
-    "@aztec/aztec.js" "3.0.0-devnet.20251212"
-    "@aztec/entrypoints" "3.0.0-devnet.20251212"
-    "@aztec/foundation" "3.0.0-devnet.20251212"
-    "@aztec/noir-contracts.js" "3.0.0-devnet.20251212"
-    "@aztec/pxe" "3.0.0-devnet.20251212"
-    "@aztec/stdlib" "3.0.0-devnet.20251212"
-    "@aztec/wallet-sdk" "3.0.0-devnet.20251212"
+    "@aztec/accounts" "3.0.0-devnet.6-patch.1"
+    "@aztec/aztec.js" "3.0.0-devnet.6-patch.1"
+    "@aztec/entrypoints" "3.0.0-devnet.6-patch.1"
+    "@aztec/foundation" "3.0.0-devnet.6-patch.1"
+    "@aztec/noir-contracts.js" "3.0.0-devnet.6-patch.1"
+    "@aztec/pxe" "3.0.0-devnet.6-patch.1"
+    "@aztec/stdlib" "3.0.0-devnet.6-patch.1"
+    "@aztec/wallet-sdk" "3.0.0-devnet.6-patch.1"
 
-"@aztec/wallet-sdk@3.0.0-devnet.20251212":
-  version "3.0.0-devnet.20251212"
-  resolved "https://registry.yarnpkg.com/@aztec/wallet-sdk/-/wallet-sdk-3.0.0-devnet.20251212.tgz#bd0e5c646582f8b73e93b6aa5c2748d1ea446f17"
-  integrity sha512-ZpH6cZgxON1S38dwKKkY2xDpjJ53G3AGOGYU4PqF6H1TXTISWxvrM/zCnt5JokGQtz+vDkze2A0rm/JtgVUebg==
+"@aztec/wallet-sdk@3.0.0-devnet.6-patch.1":
+  version "3.0.0-devnet.6-patch.1"
+  resolved "https://registry.yarnpkg.com/@aztec/wallet-sdk/-/wallet-sdk-3.0.0-devnet.6-patch.1.tgz#1ec5ac27f6d5b29758606457712c7966325b74a0"
+  integrity sha512-acshskh0gWYwanEDpc2lfwAuoexsf0halQsJRCFjMgkRW1nryEUefBGsRe0Ztq572OVNCpd8KpJRzDl4OcVjPg==
   dependencies:
-    "@aztec/aztec.js" "3.0.0-devnet.20251212"
-    "@aztec/constants" "3.0.0-devnet.20251212"
-    "@aztec/entrypoints" "3.0.0-devnet.20251212"
-    "@aztec/foundation" "3.0.0-devnet.20251212"
-    "@aztec/pxe" "3.0.0-devnet.20251212"
-    "@aztec/stdlib" "3.0.0-devnet.20251212"
+    "@aztec/aztec.js" "3.0.0-devnet.6-patch.1"
+    "@aztec/constants" "3.0.0-devnet.6-patch.1"
+    "@aztec/entrypoints" "3.0.0-devnet.6-patch.1"
+    "@aztec/foundation" "3.0.0-devnet.6-patch.1"
+    "@aztec/pxe" "3.0.0-devnet.6-patch.1"
+    "@aztec/stdlib" "3.0.0-devnet.6-patch.1"
 
-"@aztec/world-state@3.0.0-devnet.20251212":
-  version "3.0.0-devnet.20251212"
-  resolved "https://registry.yarnpkg.com/@aztec/world-state/-/world-state-3.0.0-devnet.20251212.tgz#a376363b92db3c37041611499f592849851d288a"
-  integrity sha512-YcivSND09IFwOJGuzd+KxCcey5voU0KkgDUvSXSv/l0OZQR3o1OBWO9in08GseF4FQI3SZSuLzM3hhuPwMPLgg==
+"@aztec/world-state@3.0.0-devnet.6-patch.1":
+  version "3.0.0-devnet.6-patch.1"
+  resolved "https://registry.yarnpkg.com/@aztec/world-state/-/world-state-3.0.0-devnet.6-patch.1.tgz#78b8cc83a67ca612d55e431219f2ac497ac4803e"
+  integrity sha512-6/svpdxdb/XkBGu+YH+EJZpnyCTyg4oZ31Mm1RsnYRUYz6gyZjh6w0CuiIPP3FOhnzfnvBCNrzcVK3apv7FImg==
   dependencies:
-    "@aztec/constants" "3.0.0-devnet.20251212"
-    "@aztec/foundation" "3.0.0-devnet.20251212"
-    "@aztec/kv-store" "3.0.0-devnet.20251212"
-    "@aztec/merkle-tree" "3.0.0-devnet.20251212"
-    "@aztec/native" "3.0.0-devnet.20251212"
-    "@aztec/protocol-contracts" "3.0.0-devnet.20251212"
-    "@aztec/stdlib" "3.0.0-devnet.20251212"
-    "@aztec/telemetry-client" "3.0.0-devnet.20251212"
+    "@aztec/constants" "3.0.0-devnet.6-patch.1"
+    "@aztec/foundation" "3.0.0-devnet.6-patch.1"
+    "@aztec/kv-store" "3.0.0-devnet.6-patch.1"
+    "@aztec/merkle-tree" "3.0.0-devnet.6-patch.1"
+    "@aztec/native" "3.0.0-devnet.6-patch.1"
+    "@aztec/protocol-contracts" "3.0.0-devnet.6-patch.1"
+    "@aztec/stdlib" "3.0.0-devnet.6-patch.1"
+    "@aztec/telemetry-client" "3.0.0-devnet.6-patch.1"
     tslib "^2.4.0"
     zod "^3.23.8"
 

--- a/custom-note/Nargo.toml
+++ b/custom-note/Nargo.toml
@@ -5,4 +5,4 @@ compiler_version = ">=1.0.0"
 type = "contract"
 
 [dependencies]
-aztec = { git = "https://github.com/AztecProtocol/aztec-packages/", tag = "v3.0.0-devnet.20251212", directory = "noir-projects/aztec-nr/aztec" }
+aztec = { git = "https://github.com/AztecProtocol/aztec-nr/", tag = "v3.0.0-devnet.6-patch.1", directory = "aztec" }

--- a/custom-note/README.md
+++ b/custom-note/README.md
@@ -65,12 +65,12 @@ CustomNote.view_custom_notes(owner_address)
 
 ## Dependencies
 
-- Aztec v3.0.0-devnet.20251212
+- Aztec v3.0.0-devnet.6-patch.1
 
 To set this version:
 
 ```bash
-aztec-up 3.0.0-devnet.20251212
+aztec-up 3.0.0-devnet.6-patch.1
 ```
 
 ## Project Structure

--- a/note-send-proof/circuits/Nargo.toml
+++ b/note-send-proof/circuits/Nargo.toml
@@ -4,6 +4,6 @@ type = "bin"
 authors = [""]
 
 [dependencies]
-aztec = { git = "https://github.com/AztecProtocol/aztec-packages/", tag = "v2.0.3", directory = "noir-projects/aztec-nr/aztec" }
+aztec = { git = "https://github.com/AztecProtocol/aztec-nr/", tag = "v3.0.0-devnet.6-patch.1", directory = "aztec" }
 poseidon = { tag = "v0.1.1", git = "https://github.com/noir-lang/poseidon" }
 uint_note = { path = "../uint-note" }

--- a/note-send-proof/package.json
+++ b/note-send-proof/package.json
@@ -18,12 +18,12 @@
     "typescript": "^5.0.0"
   },
   "dependencies": {
-    "@aztec/accounts": "3.0.0-devnet.20251212",
-    "@aztec/aztec.js": "3.0.0-devnet.20251212",
-    "@aztec/foundation": "3.0.0-devnet.20251212",
-    "@aztec/pxe": "3.0.0-devnet.20251212",
-    "@aztec/stdlib": "3.0.0-devnet.20251212",
-    "@aztec/test-wallet": "3.0.0-devnet.20251212",
+    "@aztec/accounts": "3.0.0-devnet.6-patch.1",
+    "@aztec/aztec.js": "3.0.0-devnet.6-patch.1",
+    "@aztec/foundation": "3.0.0-devnet.6-patch.1",
+    "@aztec/pxe": "3.0.0-devnet.6-patch.1",
+    "@aztec/stdlib": "3.0.0-devnet.6-patch.1",
+    "@aztec/test-wallet": "3.0.0-devnet.6-patch.1",
     "tsx": "^4.20.6"
   }
 }

--- a/note-send-proof/readme.md
+++ b/note-send-proof/readme.md
@@ -10,7 +10,7 @@ This project implements:
 - **Note Hash Computation**: Scripts demonstrating the v3 note hash formula
 - **Hash Verification**: Tests that verify computed unique note hashes match on-chain hashes
 
-**Aztec Version**: `3.0.0-devnet.20251212`
+**Aztec Version**: `3.0.0-devnet.6-patch.1`
 
 ## Note Hash Computation Formula (v3)
 
@@ -35,7 +35,7 @@ The unique note hash is what gets stored on-chain in the note hash tree.
 To set the correct Aztec version:
 
 ```bash
-aztec-up 3.0.0-devnet.20251212
+aztec-up 3.0.0-devnet.6-patch.1
 ```
 
 ## Project Structure
@@ -77,7 +77,7 @@ bash -i <(curl -s https://install.aztec.network)
 ### Set Aztec to the correct version:
 
 ```bash
-aztec-up 3.0.0-devnet.20251212
+aztec-up 3.0.0-devnet.6-patch.1
 ```
 
 ## Build & Compile
@@ -126,7 +126,7 @@ For a fresh setup, run these commands in order:
 yarn install
 
 # 2. Setup Aztec
-aztec-up 3.0.0-devnet.20251212
+aztec-up 3.0.0-devnet.6-patch.1
 
 # 3. Compile contract and generate TypeScript bindings
 yarn ccc

--- a/note-send-proof/sample-contract/Nargo.toml
+++ b/note-send-proof/sample-contract/Nargo.toml
@@ -5,6 +5,6 @@ compiler_version = ">=1.0.0"
 type = "contract"
 
 [dependencies]
-aztec = { git = "https://github.com/AztecProtocol/aztec-packages/", tag = "v3.0.0-devnet.20251212", directory = "noir-projects/aztec-nr/aztec" }
+aztec = { git = "https://github.com/AztecProtocol/aztec-nr/", tag = "v3.0.0-devnet.6-patch.1", directory = "aztec" }
 # Local uint_note with create_note_with_randomness for hash verification demo
 uint_note = { path = "../uint-note" }

--- a/note-send-proof/uint-note/Nargo.toml
+++ b/note-send-proof/uint-note/Nargo.toml
@@ -5,4 +5,4 @@ compiler_version = ">=1.0.0"
 type = "lib"
 
 [dependencies]
-aztec = { git = "https://github.com/AztecProtocol/aztec-packages/", tag = "v3.0.0-devnet.20251212", directory = "noir-projects/aztec-nr/aztec" }
+aztec = { git = "https://github.com/AztecProtocol/aztec-nr/", tag = "v3.0.0-devnet.6-patch.1", directory = "aztec" }

--- a/note-send-proof/yarn.lock
+++ b/note-send-proof/yarn.lock
@@ -597,59 +597,59 @@
   resolved "https://registry.yarnpkg.com/@aws/lambda-invoke-store/-/lambda-invoke-store-0.2.3.tgz#f1137f56209ccc69c15f826242cbf37f828617dd"
   integrity sha512-oLvsaPMTBejkkmHhjf09xTgk71mOqyr/409NKhRIL08If7AhVfUsJhVsx386uJaqNd42v9kWamQ9lFbkoC2dYw==
 
-"@aztec/accounts@3.0.0-devnet.20251212":
-  version "3.0.0-devnet.20251212"
-  resolved "https://registry.yarnpkg.com/@aztec/accounts/-/accounts-3.0.0-devnet.20251212.tgz#9bbc3097a7e0579e922a87880eaea760ac0e718c"
-  integrity sha512-nmXLe6N45F/V6SZWgLEvU2h58vC23eYUtuHROnaLBzh579DUv2TTSxSF8BU/1hKPKCYaloLWXy7z7F6WVMZaVg==
+"@aztec/accounts@3.0.0-devnet.6-patch.1":
+  version "3.0.0-devnet.6-patch.1"
+  resolved "https://registry.yarnpkg.com/@aztec/accounts/-/accounts-3.0.0-devnet.6-patch.1.tgz#05b44647c732e3deb723571e73c10a36d762c154"
+  integrity sha512-0iJN0t6AYgv6rxYjLSQvbwo5n8zEfJdwHoydIkqSbSLbymU5NoDnNB7jwl1omAmWqBAKN4hOr4p8Gh2ZldYIsQ==
   dependencies:
-    "@aztec/aztec.js" "3.0.0-devnet.20251212"
-    "@aztec/entrypoints" "3.0.0-devnet.20251212"
-    "@aztec/ethereum" "3.0.0-devnet.20251212"
-    "@aztec/foundation" "3.0.0-devnet.20251212"
-    "@aztec/stdlib" "3.0.0-devnet.20251212"
+    "@aztec/aztec.js" "3.0.0-devnet.6-patch.1"
+    "@aztec/entrypoints" "3.0.0-devnet.6-patch.1"
+    "@aztec/ethereum" "3.0.0-devnet.6-patch.1"
+    "@aztec/foundation" "3.0.0-devnet.6-patch.1"
+    "@aztec/stdlib" "3.0.0-devnet.6-patch.1"
     tslib "^2.4.0"
 
-"@aztec/aztec.js@3.0.0-devnet.20251212":
-  version "3.0.0-devnet.20251212"
-  resolved "https://registry.yarnpkg.com/@aztec/aztec.js/-/aztec.js-3.0.0-devnet.20251212.tgz#8c84a5a60bf092360f6f80c6575b38c3dc41aa74"
-  integrity sha512-k0o3fZlDEf8XaBDFIhKIOgQES09/xOiCNnaaCBwfQgifPtxHKsdTnomXHVVwgJWD/gS7TtwLnNfvjYmEKy50cA==
+"@aztec/aztec.js@3.0.0-devnet.6-patch.1":
+  version "3.0.0-devnet.6-patch.1"
+  resolved "https://registry.yarnpkg.com/@aztec/aztec.js/-/aztec.js-3.0.0-devnet.6-patch.1.tgz#cbf2c015c76a7e346044cf6a0b7724f1a85d661f"
+  integrity sha512-vPba9qQg1IUyg9aTyzEJfHwtwb7guCF2BiBAwnqPKkhoSG06CoDHQfU7T+JqxY9QpdWqDGUSfvDCr5wRFlEL0g==
   dependencies:
-    "@aztec/constants" "3.0.0-devnet.20251212"
-    "@aztec/entrypoints" "3.0.0-devnet.20251212"
-    "@aztec/ethereum" "3.0.0-devnet.20251212"
-    "@aztec/foundation" "3.0.0-devnet.20251212"
-    "@aztec/l1-artifacts" "3.0.0-devnet.20251212"
-    "@aztec/protocol-contracts" "3.0.0-devnet.20251212"
-    "@aztec/stdlib" "3.0.0-devnet.20251212"
+    "@aztec/constants" "3.0.0-devnet.6-patch.1"
+    "@aztec/entrypoints" "3.0.0-devnet.6-patch.1"
+    "@aztec/ethereum" "3.0.0-devnet.6-patch.1"
+    "@aztec/foundation" "3.0.0-devnet.6-patch.1"
+    "@aztec/l1-artifacts" "3.0.0-devnet.6-patch.1"
+    "@aztec/protocol-contracts" "3.0.0-devnet.6-patch.1"
+    "@aztec/stdlib" "3.0.0-devnet.6-patch.1"
     axios "^1.12.0"
     tslib "^2.4.0"
     viem "npm:@aztec/viem@2.38.2"
     zod "^3.23.8"
 
-"@aztec/bb-prover@3.0.0-devnet.20251212":
-  version "3.0.0-devnet.20251212"
-  resolved "https://registry.yarnpkg.com/@aztec/bb-prover/-/bb-prover-3.0.0-devnet.20251212.tgz#86540c0272e910cbc35dffc97119dbf712521f94"
-  integrity sha512-wFb3yVIoZSCdcmcZTKBHsdzNtvt8S3nVhPFagoEL6ts8fJtrzYS1tYZ5mLukpwILkNJGnb+R+SLpaWEBnU7fTg==
+"@aztec/bb-prover@3.0.0-devnet.6-patch.1":
+  version "3.0.0-devnet.6-patch.1"
+  resolved "https://registry.yarnpkg.com/@aztec/bb-prover/-/bb-prover-3.0.0-devnet.6-patch.1.tgz#22155bbba2571eddf2cbc0cf0eccc3000224ce95"
+  integrity sha512-SMuVhCN6iA4WJOdk2Aj1iuK/+6I27cWCu0V/rm1ZQyNEryPteIXKnXleG5HWSZ+MRIngOAut+hT8cFhHRSfrLA==
   dependencies:
-    "@aztec/bb.js" "3.0.0-devnet.20251212"
-    "@aztec/constants" "3.0.0-devnet.20251212"
-    "@aztec/foundation" "3.0.0-devnet.20251212"
-    "@aztec/noir-noirc_abi" "3.0.0-devnet.20251212"
-    "@aztec/noir-protocol-circuits-types" "3.0.0-devnet.20251212"
-    "@aztec/noir-types" "3.0.0-devnet.20251212"
-    "@aztec/simulator" "3.0.0-devnet.20251212"
-    "@aztec/stdlib" "3.0.0-devnet.20251212"
-    "@aztec/telemetry-client" "3.0.0-devnet.20251212"
-    "@aztec/world-state" "3.0.0-devnet.20251212"
+    "@aztec/bb.js" "3.0.0-devnet.6-patch.1"
+    "@aztec/constants" "3.0.0-devnet.6-patch.1"
+    "@aztec/foundation" "3.0.0-devnet.6-patch.1"
+    "@aztec/noir-noirc_abi" "3.0.0-devnet.6-patch.1"
+    "@aztec/noir-protocol-circuits-types" "3.0.0-devnet.6-patch.1"
+    "@aztec/noir-types" "3.0.0-devnet.6-patch.1"
+    "@aztec/simulator" "3.0.0-devnet.6-patch.1"
+    "@aztec/stdlib" "3.0.0-devnet.6-patch.1"
+    "@aztec/telemetry-client" "3.0.0-devnet.6-patch.1"
+    "@aztec/world-state" "3.0.0-devnet.6-patch.1"
     commander "^12.1.0"
     pako "^2.1.0"
     source-map-support "^0.5.21"
     tslib "^2.4.0"
 
-"@aztec/bb.js@3.0.0-devnet.20251212":
-  version "3.0.0-devnet.20251212"
-  resolved "https://registry.yarnpkg.com/@aztec/bb.js/-/bb.js-3.0.0-devnet.20251212.tgz#cbf4c76db7b57f5515a0e1168b37200a9e91734b"
-  integrity sha512-9xqm3d9H9aDus8xGf7b7Bd9rkjYqp1PHHMmqNT8FJ/Rv5Pn/rJgwE+d4ZWJtm+inIIu8D8AeKTBc9bEEPjENUQ==
+"@aztec/bb.js@3.0.0-devnet.6-patch.1":
+  version "3.0.0-devnet.6-patch.1"
+  resolved "https://registry.yarnpkg.com/@aztec/bb.js/-/bb.js-3.0.0-devnet.6-patch.1.tgz#6781fa91d7faeb5a3bc1e3f8fabc4ddd4a9bb92c"
+  integrity sha512-ULRG/Ky5h2Lpaw4lXjkEzJdQVgfCFhBY9Fb0mL+Y+yC+thi2T5rQmmAwh5Qmr7F+KwKcozgtryV7Ook3rVjbhA==
   dependencies:
     comlink "^4.4.1"
     commander "^12.1.0"
@@ -658,54 +658,54 @@
     pako "^2.1.0"
     tslib "^2.4.0"
 
-"@aztec/blob-lib@3.0.0-devnet.20251212":
-  version "3.0.0-devnet.20251212"
-  resolved "https://registry.yarnpkg.com/@aztec/blob-lib/-/blob-lib-3.0.0-devnet.20251212.tgz#cc8f3e89b0078b761e46e6adbdf3e57e0480db4a"
-  integrity sha512-DiJBFkcPxuGBN51S6EaJfU+UxejcOwUzKFAIskPIHheb0kSFAad/4VVhhadtCudN72+iIBCExUtp7qBdJmePYQ==
+"@aztec/blob-lib@3.0.0-devnet.6-patch.1":
+  version "3.0.0-devnet.6-patch.1"
+  resolved "https://registry.yarnpkg.com/@aztec/blob-lib/-/blob-lib-3.0.0-devnet.6-patch.1.tgz#ca476037b413acbe75766785e5b26da09afe8c54"
+  integrity sha512-l3YxkxfAm3RF7016QHXFxlQF58wgSpI0u7xfe6NpupO7k3gnCOrLm8p6GcBGcIoTIcf5GJzK2QfZvBsX+WVZHw==
   dependencies:
-    "@aztec/constants" "3.0.0-devnet.20251212"
-    "@aztec/foundation" "3.0.0-devnet.20251212"
+    "@aztec/constants" "3.0.0-devnet.6-patch.1"
+    "@aztec/foundation" "3.0.0-devnet.6-patch.1"
     "@crate-crypto/node-eth-kzg" "^0.10.0"
     tslib "^2.4.0"
 
-"@aztec/builder@3.0.0-devnet.20251212":
-  version "3.0.0-devnet.20251212"
-  resolved "https://registry.yarnpkg.com/@aztec/builder/-/builder-3.0.0-devnet.20251212.tgz#1befe5bc1d0f10e87820fd775ad279589664360e"
-  integrity sha512-BUvWzdwUK7jnfpjsvdgbOpAvdZi3njH3MQHSIW3VYyEgUlVNT9NJtmCzY222vnBPeN4XLkNwBSaEe1DH+VuULw==
+"@aztec/builder@3.0.0-devnet.6-patch.1":
+  version "3.0.0-devnet.6-patch.1"
+  resolved "https://registry.yarnpkg.com/@aztec/builder/-/builder-3.0.0-devnet.6-patch.1.tgz#a25cd90e83e8c2595c6a3c0440c683e42e258af2"
+  integrity sha512-IPBXJVhDu3T3K59uVCBX/jK+/Wkn5Z0coBzlcRQkr6puLv8sZod8vPwPrEGeWxOYz6VZN7JUkJup5ZqKR2vFgg==
   dependencies:
-    "@aztec/foundation" "3.0.0-devnet.20251212"
-    "@aztec/stdlib" "3.0.0-devnet.20251212"
+    "@aztec/foundation" "3.0.0-devnet.6-patch.1"
+    "@aztec/stdlib" "3.0.0-devnet.6-patch.1"
     commander "^12.1.0"
 
-"@aztec/constants@3.0.0-devnet.20251212":
-  version "3.0.0-devnet.20251212"
-  resolved "https://registry.yarnpkg.com/@aztec/constants/-/constants-3.0.0-devnet.20251212.tgz#2960ebfea2852313c76af6b967c53958e03006cb"
-  integrity sha512-R0pYLhWUnDago/MO8+iuG/2yrP4yVDZuQvOmXwDqp5ed+SR4zj8sqvC52paXrOxhcLpheVpEHp2TuGKtmssvtg==
+"@aztec/constants@3.0.0-devnet.6-patch.1":
+  version "3.0.0-devnet.6-patch.1"
+  resolved "https://registry.yarnpkg.com/@aztec/constants/-/constants-3.0.0-devnet.6-patch.1.tgz#c0588e4039de977949b997cb65f45721539cf6bd"
+  integrity sha512-YKH/JQ+Qpd8X9xtWwTBc1yVChjfO9yKFPH2x/LIll89rkPT9GU3OKQeKpnXOKlnC/2IWW2ZExASfwttp8TWtXg==
   dependencies:
-    "@aztec/foundation" "3.0.0-devnet.20251212"
+    "@aztec/foundation" "3.0.0-devnet.6-patch.1"
     tslib "^2.4.0"
 
-"@aztec/entrypoints@3.0.0-devnet.20251212":
-  version "3.0.0-devnet.20251212"
-  resolved "https://registry.yarnpkg.com/@aztec/entrypoints/-/entrypoints-3.0.0-devnet.20251212.tgz#a67151a3d9c078b91bf8e3869cddd64c784eaab5"
-  integrity sha512-XlMkUqetlM1lzVycxmIdQ1FtM2kfFtKU+7GG01mGnhawFHJnBT8EqMQjxaSKCO9fQYTNIl1oUELhyzpiWL/ztg==
+"@aztec/entrypoints@3.0.0-devnet.6-patch.1":
+  version "3.0.0-devnet.6-patch.1"
+  resolved "https://registry.yarnpkg.com/@aztec/entrypoints/-/entrypoints-3.0.0-devnet.6-patch.1.tgz#ade9929ab6351c990844649b62a2ccc7ce474400"
+  integrity sha512-rHVRJGk7rxw16rxxQzfojnYjqK0zBtQVghLj1+4p91looN0T4xS8sEXr4jCGPG78uj3NLkYLuPQCQCDVmWXVcA==
   dependencies:
-    "@aztec/constants" "3.0.0-devnet.20251212"
-    "@aztec/foundation" "3.0.0-devnet.20251212"
-    "@aztec/protocol-contracts" "3.0.0-devnet.20251212"
-    "@aztec/stdlib" "3.0.0-devnet.20251212"
+    "@aztec/constants" "3.0.0-devnet.6-patch.1"
+    "@aztec/foundation" "3.0.0-devnet.6-patch.1"
+    "@aztec/protocol-contracts" "3.0.0-devnet.6-patch.1"
+    "@aztec/stdlib" "3.0.0-devnet.6-patch.1"
     tslib "^2.4.0"
     zod "^3.23.8"
 
-"@aztec/ethereum@3.0.0-devnet.20251212":
-  version "3.0.0-devnet.20251212"
-  resolved "https://registry.yarnpkg.com/@aztec/ethereum/-/ethereum-3.0.0-devnet.20251212.tgz#910f811f04c319edbde9d1af192b8753936061ba"
-  integrity sha512-smAL13K73bpP5SXDYoYukQsnOa6iHC7a1HP1tf3Llk9mF0hS1BXV+kyrltiVeVHSN5/UkZN4WZ50yQ5CCeq6rg==
+"@aztec/ethereum@3.0.0-devnet.6-patch.1":
+  version "3.0.0-devnet.6-patch.1"
+  resolved "https://registry.yarnpkg.com/@aztec/ethereum/-/ethereum-3.0.0-devnet.6-patch.1.tgz#16a1f80facf54441b4f606d01fa0a83103f6d74f"
+  integrity sha512-J1QxJFpYIcWw3Se8eVBWMTvZsGTngwz7h6wgWEkUj2noFe2zPpvASGe389rrHPqqdsQ70yZ92kDaHQ2KyhDzLw==
   dependencies:
-    "@aztec/blob-lib" "3.0.0-devnet.20251212"
-    "@aztec/constants" "3.0.0-devnet.20251212"
-    "@aztec/foundation" "3.0.0-devnet.20251212"
-    "@aztec/l1-artifacts" "3.0.0-devnet.20251212"
+    "@aztec/blob-lib" "3.0.0-devnet.6-patch.1"
+    "@aztec/constants" "3.0.0-devnet.6-patch.1"
+    "@aztec/foundation" "3.0.0-devnet.6-patch.1"
+    "@aztec/l1-artifacts" "3.0.0-devnet.6-patch.1"
     "@viem/anvil" "^0.0.10"
     dotenv "^16.0.3"
     lodash.chunk "^4.2.0"
@@ -714,12 +714,12 @@
     viem "npm:@aztec/viem@2.38.2"
     zod "^3.23.8"
 
-"@aztec/foundation@3.0.0-devnet.20251212":
-  version "3.0.0-devnet.20251212"
-  resolved "https://registry.yarnpkg.com/@aztec/foundation/-/foundation-3.0.0-devnet.20251212.tgz#2871a76946ee051b7a42cbf9c9defa08220ea054"
-  integrity sha512-1yBGAJCO4VjmaZTx5qbJ2vW8yjWlLae524L08zOSGoEqF2RIkCvbQyIOaH/ZWb5n866LP66XhUfoaohPmgK+EA==
+"@aztec/foundation@3.0.0-devnet.6-patch.1":
+  version "3.0.0-devnet.6-patch.1"
+  resolved "https://registry.yarnpkg.com/@aztec/foundation/-/foundation-3.0.0-devnet.6-patch.1.tgz#feacdef89029695ccec0fa7d419faf595d5ab27a"
+  integrity sha512-8oNaZPdU0vMRPxHZzwkOfEPsC9IRswP1WXCqxgdQHYSufYNxNrDZ7aVQpuI0sPkA3BsCXzPb/tQTgD+E2WoYEQ==
   dependencies:
-    "@aztec/bb.js" "3.0.0-devnet.20251212"
+    "@aztec/bb.js" "3.0.0-devnet.6-patch.1"
     "@koa/cors" "^5.0.0"
     "@noble/curves" "=1.7.0"
     "@noble/hashes" "^1.6.1"
@@ -742,140 +742,140 @@
     undici "^5.28.5"
     zod "^3.23.8"
 
-"@aztec/key-store@3.0.0-devnet.20251212":
-  version "3.0.0-devnet.20251212"
-  resolved "https://registry.yarnpkg.com/@aztec/key-store/-/key-store-3.0.0-devnet.20251212.tgz#0d0bf89969a8e8a5f1f0db86d1f1cd703478af19"
-  integrity sha512-FMh8hsXZNMMz+DHDdKgTyeNfdH0FHiwQygDdi3n2rRr0Io7Jc3HMPqB3w5dFt8qKxTelNmFqll5XRu5IZDuAvg==
+"@aztec/key-store@3.0.0-devnet.6-patch.1":
+  version "3.0.0-devnet.6-patch.1"
+  resolved "https://registry.yarnpkg.com/@aztec/key-store/-/key-store-3.0.0-devnet.6-patch.1.tgz#962c91aa606131a6e38ab2845049bd07d7e46781"
+  integrity sha512-LV3JhRG0RW5O4CK5dB4MEOQQHM+N6HwHeQrJG9tZr5P52GzwT7PlBPmopzuq/iKIh48MNizfMTux5681UqBe2Q==
   dependencies:
-    "@aztec/constants" "3.0.0-devnet.20251212"
-    "@aztec/foundation" "3.0.0-devnet.20251212"
-    "@aztec/kv-store" "3.0.0-devnet.20251212"
-    "@aztec/stdlib" "3.0.0-devnet.20251212"
+    "@aztec/constants" "3.0.0-devnet.6-patch.1"
+    "@aztec/foundation" "3.0.0-devnet.6-patch.1"
+    "@aztec/kv-store" "3.0.0-devnet.6-patch.1"
+    "@aztec/stdlib" "3.0.0-devnet.6-patch.1"
     tslib "^2.4.0"
 
-"@aztec/kv-store@3.0.0-devnet.20251212":
-  version "3.0.0-devnet.20251212"
-  resolved "https://registry.yarnpkg.com/@aztec/kv-store/-/kv-store-3.0.0-devnet.20251212.tgz#6199beb780558a180200f9cc1b246fd7df009af1"
-  integrity sha512-Qe1aYRpQFHFwsvtNKLHphKNYxEB4vIOSqqgFME8oYw3nsq2AlV/Byrmw0x3jXVc15QLc6x8uTn1rXqpZK+u3tA==
+"@aztec/kv-store@3.0.0-devnet.6-patch.1":
+  version "3.0.0-devnet.6-patch.1"
+  resolved "https://registry.yarnpkg.com/@aztec/kv-store/-/kv-store-3.0.0-devnet.6-patch.1.tgz#19850f5423a7d45d59656a50e57bad478599fe2c"
+  integrity sha512-Y3hMLidonMlN3eC/Blc+o6dN9VY+byLJsPXvNu+snGc6QR8rPw2x+vM/+QInsx9AFoIRfDjZU+64QMLKS4bizw==
   dependencies:
-    "@aztec/constants" "3.0.0-devnet.20251212"
-    "@aztec/ethereum" "3.0.0-devnet.20251212"
-    "@aztec/foundation" "3.0.0-devnet.20251212"
-    "@aztec/native" "3.0.0-devnet.20251212"
-    "@aztec/stdlib" "3.0.0-devnet.20251212"
+    "@aztec/constants" "3.0.0-devnet.6-patch.1"
+    "@aztec/ethereum" "3.0.0-devnet.6-patch.1"
+    "@aztec/foundation" "3.0.0-devnet.6-patch.1"
+    "@aztec/native" "3.0.0-devnet.6-patch.1"
+    "@aztec/stdlib" "3.0.0-devnet.6-patch.1"
     idb "^8.0.0"
     lmdb "^3.2.0"
     msgpackr "^1.11.2"
     ohash "^2.0.11"
     ordered-binary "^1.5.3"
 
-"@aztec/l1-artifacts@3.0.0-devnet.20251212":
-  version "3.0.0-devnet.20251212"
-  resolved "https://registry.yarnpkg.com/@aztec/l1-artifacts/-/l1-artifacts-3.0.0-devnet.20251212.tgz#431713cd66794eb8d890f0f379a55809a7822e61"
-  integrity sha512-IGWQ8ie2W1Ok8bLnfmuvazULT9dPj9ozYDujcgI+lWYnUbTDR5ja7tfx9qG//9Um+FFKZL5JErm0qtsPSrO2tg==
+"@aztec/l1-artifacts@3.0.0-devnet.6-patch.1":
+  version "3.0.0-devnet.6-patch.1"
+  resolved "https://registry.yarnpkg.com/@aztec/l1-artifacts/-/l1-artifacts-3.0.0-devnet.6-patch.1.tgz#fb017bcf65cfa9a9610b64ad0dcc7ff4fd46b0b2"
+  integrity sha512-aO01TaullALg6Mn/GK/HgB9AB+8mxyrQi7X9It/i2u+SA8UiIQuwoBzr3uAA1hsWnRCSD+M7RikMBvVmVDlYkg==
   dependencies:
     tslib "^2.4.0"
 
-"@aztec/merkle-tree@3.0.0-devnet.20251212":
-  version "3.0.0-devnet.20251212"
-  resolved "https://registry.yarnpkg.com/@aztec/merkle-tree/-/merkle-tree-3.0.0-devnet.20251212.tgz#f9ecfd673d0639f9629906e5610fbe5e06dff824"
-  integrity sha512-uXJm69QJElxnnPah7JSynsw7+xaVzIOWFxqYLP9QgQG7M1MyYE9WQyK78LMRUb8iG3sW84udFcvdSuCMwL1YEw==
+"@aztec/merkle-tree@3.0.0-devnet.6-patch.1":
+  version "3.0.0-devnet.6-patch.1"
+  resolved "https://registry.yarnpkg.com/@aztec/merkle-tree/-/merkle-tree-3.0.0-devnet.6-patch.1.tgz#df973c1eea7ff561fc6b6545575df7813d32f10e"
+  integrity sha512-u6jt+4ATePLnCzACe1VGNYEjbRKDj19xgLtVa+nzcBBO527UIueKxQxjPZ8j9yMcLPGrSvDTdBqaOdm7uWPI4Q==
   dependencies:
-    "@aztec/foundation" "3.0.0-devnet.20251212"
-    "@aztec/kv-store" "3.0.0-devnet.20251212"
-    "@aztec/stdlib" "3.0.0-devnet.20251212"
+    "@aztec/foundation" "3.0.0-devnet.6-patch.1"
+    "@aztec/kv-store" "3.0.0-devnet.6-patch.1"
+    "@aztec/stdlib" "3.0.0-devnet.6-patch.1"
     sha256 "^0.2.0"
     tslib "^2.4.0"
 
-"@aztec/native@3.0.0-devnet.20251212":
-  version "3.0.0-devnet.20251212"
-  resolved "https://registry.yarnpkg.com/@aztec/native/-/native-3.0.0-devnet.20251212.tgz#eaaecdbacee3295077219de400b8eafa4c8c5e8a"
-  integrity sha512-UIUjQRK2S54Pr0tZinUek7rjtfh0fZbdxJFzEFTBElO/g5rExK8FUX8S1Fz3DfFOJNgBj9Y8RW2oj3yZEKxTvw==
+"@aztec/native@3.0.0-devnet.6-patch.1":
+  version "3.0.0-devnet.6-patch.1"
+  resolved "https://registry.yarnpkg.com/@aztec/native/-/native-3.0.0-devnet.6-patch.1.tgz#601c5bac626ea5fd60d45820205ec4b54c67f9c8"
+  integrity sha512-UNTdTD/sKJFzCjFjUcpX3g1ElxyIIDkkaMJek6CCb1rsXVtALgIx6K7QhRq26hkUPgS0pBpFPgznFOvh1bsE8w==
   dependencies:
-    "@aztec/bb.js" "3.0.0-devnet.20251212"
-    "@aztec/foundation" "3.0.0-devnet.20251212"
+    "@aztec/bb.js" "3.0.0-devnet.6-patch.1"
+    "@aztec/foundation" "3.0.0-devnet.6-patch.1"
     msgpackr "^1.11.2"
 
-"@aztec/noir-acvm_js@3.0.0-devnet.20251212":
-  version "3.0.0-devnet.20251212"
-  resolved "https://registry.yarnpkg.com/@aztec/noir-acvm_js/-/noir-acvm_js-3.0.0-devnet.20251212.tgz#efe93e644afed661fe6d5b17f4fd5cc273fa4e21"
-  integrity sha512-vQujIYW0urROyi/+REygX1YyHuHSBMSFyOc2P7pyFEILmlMH8ZLyLjtUWHm8bUa8gq8G+zsd7Bn2p+MEiBhMtg==
+"@aztec/noir-acvm_js@3.0.0-devnet.6-patch.1":
+  version "3.0.0-devnet.6-patch.1"
+  resolved "https://registry.yarnpkg.com/@aztec/noir-acvm_js/-/noir-acvm_js-3.0.0-devnet.6-patch.1.tgz#c6930c121c2a186cb7a071d46ff59b1ddda97da0"
+  integrity sha512-gJTPvM2bDzj+sVH5gmWgBo0tNyaecWyXmYwZCP4Cz5DtwfN7bcT4JAmjLex0u85i6rpJ+ij9ayPB8msqhvLJSw==
 
-"@aztec/noir-contracts.js@3.0.0-devnet.20251212":
-  version "3.0.0-devnet.20251212"
-  resolved "https://registry.yarnpkg.com/@aztec/noir-contracts.js/-/noir-contracts.js-3.0.0-devnet.20251212.tgz#91602e1ab1b517a12ebb90c868c1bd22d706c34d"
-  integrity sha512-+Jl3za8TTK9VkiDitj6cMCdpmD0A3buvafoVNPmTUU8AvO1YMTrs6OPDvMEXKVpmwRZI6zOCPF+0H1u9zDW5BA==
+"@aztec/noir-contracts.js@3.0.0-devnet.6-patch.1":
+  version "3.0.0-devnet.6-patch.1"
+  resolved "https://registry.yarnpkg.com/@aztec/noir-contracts.js/-/noir-contracts.js-3.0.0-devnet.6-patch.1.tgz#b9fdfec34de536ae579e3481177a046c27bf3598"
+  integrity sha512-GP1VX+qm5bkSsGpeekCWaLOAoMPFqpckx/WIqAyxJLlSTS7QuvANEulGJI22IBhktu133CtXXfzjATHPEGbN4g==
   dependencies:
-    "@aztec/aztec.js" "3.0.0-devnet.20251212"
+    "@aztec/aztec.js" "3.0.0-devnet.6-patch.1"
     tslib "^2.4.0"
 
-"@aztec/noir-noir_codegen@3.0.0-devnet.20251212":
-  version "3.0.0-devnet.20251212"
-  resolved "https://registry.yarnpkg.com/@aztec/noir-noir_codegen/-/noir-noir_codegen-3.0.0-devnet.20251212.tgz#8a278ca2f2e3e5c524047b96166ebe987dba00d0"
-  integrity sha512-yl1+tmypfKODxsq6PxPsCjRJokI3S+rU6gNvO6XLQTRuFkDIDfp4qDoevD9VnZvjtkataS2z99AylsJdxFToEQ==
+"@aztec/noir-noir_codegen@3.0.0-devnet.6-patch.1":
+  version "3.0.0-devnet.6-patch.1"
+  resolved "https://registry.yarnpkg.com/@aztec/noir-noir_codegen/-/noir-noir_codegen-3.0.0-devnet.6-patch.1.tgz#d7d614cb2cb828766977298076d8c3c48da95e16"
+  integrity sha512-dTvCSdNhSavN5vQ4rBZjD5A2mTgwnRXlNM4wOfJgk1bZEeuapJpD1bc98nV5e4a8C/G0TRgQT7CaxbrHluDdpw==
   dependencies:
-    "@aztec/noir-types" "3.0.0-devnet.20251212"
+    "@aztec/noir-types" "3.0.0-devnet.6-patch.1"
     glob "^11.0.3"
     ts-command-line-args "^2.5.1"
 
-"@aztec/noir-noirc_abi@3.0.0-devnet.20251212":
-  version "3.0.0-devnet.20251212"
-  resolved "https://registry.yarnpkg.com/@aztec/noir-noirc_abi/-/noir-noirc_abi-3.0.0-devnet.20251212.tgz#368242d4b23f3627086e00588bb34573fba69b46"
-  integrity sha512-HuABbS7Cr4xXFQ3Fqq86hoDzbAnxe7iXJK6Oow6Ak8PqNu1kdvZpwLLMpDvTE/1sCio+lEbnNmxpp5ko2yckSQ==
+"@aztec/noir-noirc_abi@3.0.0-devnet.6-patch.1":
+  version "3.0.0-devnet.6-patch.1"
+  resolved "https://registry.yarnpkg.com/@aztec/noir-noirc_abi/-/noir-noirc_abi-3.0.0-devnet.6-patch.1.tgz#9cc1a1ebbce77f74a9c08d587c9363bd28c99b36"
+  integrity sha512-+J9StgFWBSi+zhGTmXXNbe3LV3lJ7FC4nmwQP6VENVLzoo1icT6S77N0xrfbcHCbdqmzw8FtKz0BR69VuXdChQ==
   dependencies:
-    "@aztec/noir-types" "3.0.0-devnet.20251212"
+    "@aztec/noir-types" "3.0.0-devnet.6-patch.1"
 
-"@aztec/noir-protocol-circuits-types@3.0.0-devnet.20251212":
-  version "3.0.0-devnet.20251212"
-  resolved "https://registry.yarnpkg.com/@aztec/noir-protocol-circuits-types/-/noir-protocol-circuits-types-3.0.0-devnet.20251212.tgz#174eadaaba675393983609a5a5683d0e69912075"
-  integrity sha512-gBz5UbR1QV5bmg/6y+an77GEJmM2ed1/UCtJwGmbRjhA6Bq+l8ghTphAFtO2eOs/OOp6vaEOBWBCEvTUpF/j0w==
+"@aztec/noir-protocol-circuits-types@3.0.0-devnet.6-patch.1":
+  version "3.0.0-devnet.6-patch.1"
+  resolved "https://registry.yarnpkg.com/@aztec/noir-protocol-circuits-types/-/noir-protocol-circuits-types-3.0.0-devnet.6-patch.1.tgz#1abd030097cb9540d4bee70d8d133a3c5a587945"
+  integrity sha512-/e8nlQjsZIE1OKE53zlH8EJUkw24/IEZ3Zsj4HNoSQvKz63Zu0yoNrTst02owUYqTprrDuFj5YL8qouTo3UsXA==
   dependencies:
-    "@aztec/blob-lib" "3.0.0-devnet.20251212"
-    "@aztec/constants" "3.0.0-devnet.20251212"
-    "@aztec/foundation" "3.0.0-devnet.20251212"
-    "@aztec/noir-acvm_js" "3.0.0-devnet.20251212"
-    "@aztec/noir-noir_codegen" "3.0.0-devnet.20251212"
-    "@aztec/noir-noirc_abi" "3.0.0-devnet.20251212"
-    "@aztec/noir-types" "3.0.0-devnet.20251212"
-    "@aztec/stdlib" "3.0.0-devnet.20251212"
+    "@aztec/blob-lib" "3.0.0-devnet.6-patch.1"
+    "@aztec/constants" "3.0.0-devnet.6-patch.1"
+    "@aztec/foundation" "3.0.0-devnet.6-patch.1"
+    "@aztec/noir-acvm_js" "3.0.0-devnet.6-patch.1"
+    "@aztec/noir-noir_codegen" "3.0.0-devnet.6-patch.1"
+    "@aztec/noir-noirc_abi" "3.0.0-devnet.6-patch.1"
+    "@aztec/noir-types" "3.0.0-devnet.6-patch.1"
+    "@aztec/stdlib" "3.0.0-devnet.6-patch.1"
     change-case "^5.4.4"
     tslib "^2.4.0"
 
-"@aztec/noir-types@3.0.0-devnet.20251212":
-  version "3.0.0-devnet.20251212"
-  resolved "https://registry.yarnpkg.com/@aztec/noir-types/-/noir-types-3.0.0-devnet.20251212.tgz#878793c148d4305e0113963fdbdd4a4791fca01e"
-  integrity sha512-cFgkHsupyJmDkN/MEP7EDgG9pBKO4jGNH9Y3d3t0OIhRjlberBRv0HtlcfTfaKeM2DZ2x/Lloov+5J6mfuyMrA==
+"@aztec/noir-types@3.0.0-devnet.6-patch.1":
+  version "3.0.0-devnet.6-patch.1"
+  resolved "https://registry.yarnpkg.com/@aztec/noir-types/-/noir-types-3.0.0-devnet.6-patch.1.tgz#ce91b70427983bf32bb013d6c86b0b2e348956c3"
+  integrity sha512-zj7/ERBvTcnypoytwk4RBiN4mBe1kRVZJpd9byUPc5p9vVqi2uYkbaLa1JpjwyKShItWXU6TXv6C8V23jj5mGA==
 
-"@aztec/protocol-contracts@3.0.0-devnet.20251212":
-  version "3.0.0-devnet.20251212"
-  resolved "https://registry.yarnpkg.com/@aztec/protocol-contracts/-/protocol-contracts-3.0.0-devnet.20251212.tgz#d08620926a4370995b58a2ba4341a8324d82b8ab"
-  integrity sha512-AZSTimslrwiyc4d3doifGQcUmayuYDZkD+Eo/U9udIz4uexljVgOVCNMbciDbDGDuEkKEd6mg/W/YlAcTqCdqQ==
+"@aztec/protocol-contracts@3.0.0-devnet.6-patch.1":
+  version "3.0.0-devnet.6-patch.1"
+  resolved "https://registry.yarnpkg.com/@aztec/protocol-contracts/-/protocol-contracts-3.0.0-devnet.6-patch.1.tgz#b5a79b19041593744d776a0adb9c0e1f99d50ca7"
+  integrity sha512-QbpoSNLZ54xzAmeen3t+oJEKoeoqD84mrP+ooFgLNPwuXAU48BP5Otq3aZIycIfTcjXnjIhORzLURX0ftU3sKg==
   dependencies:
-    "@aztec/constants" "3.0.0-devnet.20251212"
-    "@aztec/foundation" "3.0.0-devnet.20251212"
-    "@aztec/stdlib" "3.0.0-devnet.20251212"
+    "@aztec/constants" "3.0.0-devnet.6-patch.1"
+    "@aztec/foundation" "3.0.0-devnet.6-patch.1"
+    "@aztec/stdlib" "3.0.0-devnet.6-patch.1"
     lodash.chunk "^4.2.0"
     lodash.omit "^4.5.0"
     tslib "^2.4.0"
 
-"@aztec/pxe@3.0.0-devnet.20251212":
-  version "3.0.0-devnet.20251212"
-  resolved "https://registry.yarnpkg.com/@aztec/pxe/-/pxe-3.0.0-devnet.20251212.tgz#dd9916163a41ed1c8532768ac8f92fa1e2426468"
-  integrity sha512-wmg2emJsutWNnHCuly+2t/C43PFEtGqoHzkCSsDhfgWDgjtaScROyaGoCHyNjqGDJvhfe5HQ+cfGjjEuYia0Qw==
+"@aztec/pxe@3.0.0-devnet.6-patch.1":
+  version "3.0.0-devnet.6-patch.1"
+  resolved "https://registry.yarnpkg.com/@aztec/pxe/-/pxe-3.0.0-devnet.6-patch.1.tgz#996f07b034f8f97a254ed4d5bc8814e339f9e709"
+  integrity sha512-ugKffEjNH+U6EfkVuXceozQhmbHgCtLmNx2Jxl02hzW44/41lmL05zAHXCL5IKi+5NfyaRmMjxFJ898jXKa8Lw==
   dependencies:
-    "@aztec/bb-prover" "3.0.0-devnet.20251212"
-    "@aztec/bb.js" "3.0.0-devnet.20251212"
-    "@aztec/builder" "3.0.0-devnet.20251212"
-    "@aztec/constants" "3.0.0-devnet.20251212"
-    "@aztec/ethereum" "3.0.0-devnet.20251212"
-    "@aztec/foundation" "3.0.0-devnet.20251212"
-    "@aztec/key-store" "3.0.0-devnet.20251212"
-    "@aztec/kv-store" "3.0.0-devnet.20251212"
-    "@aztec/noir-protocol-circuits-types" "3.0.0-devnet.20251212"
-    "@aztec/noir-types" "3.0.0-devnet.20251212"
-    "@aztec/protocol-contracts" "3.0.0-devnet.20251212"
-    "@aztec/simulator" "3.0.0-devnet.20251212"
-    "@aztec/stdlib" "3.0.0-devnet.20251212"
+    "@aztec/bb-prover" "3.0.0-devnet.6-patch.1"
+    "@aztec/bb.js" "3.0.0-devnet.6-patch.1"
+    "@aztec/builder" "3.0.0-devnet.6-patch.1"
+    "@aztec/constants" "3.0.0-devnet.6-patch.1"
+    "@aztec/ethereum" "3.0.0-devnet.6-patch.1"
+    "@aztec/foundation" "3.0.0-devnet.6-patch.1"
+    "@aztec/key-store" "3.0.0-devnet.6-patch.1"
+    "@aztec/kv-store" "3.0.0-devnet.6-patch.1"
+    "@aztec/noir-protocol-circuits-types" "3.0.0-devnet.6-patch.1"
+    "@aztec/noir-types" "3.0.0-devnet.6-patch.1"
+    "@aztec/protocol-contracts" "3.0.0-devnet.6-patch.1"
+    "@aztec/simulator" "3.0.0-devnet.6-patch.1"
+    "@aztec/stdlib" "3.0.0-devnet.6-patch.1"
     koa "^2.16.1"
     koa-router "^13.1.1"
     lodash.omit "^4.5.0"
@@ -883,39 +883,39 @@
     tslib "^2.4.0"
     viem "npm:@aztec/viem@2.38.2"
 
-"@aztec/simulator@3.0.0-devnet.20251212":
-  version "3.0.0-devnet.20251212"
-  resolved "https://registry.yarnpkg.com/@aztec/simulator/-/simulator-3.0.0-devnet.20251212.tgz#da2f87175593acbb6a830c99a7e4a0992d3897b7"
-  integrity sha512-juVBLvDEMBPkzg6gaxtRGeuBiPq35S1BEI1L5Y1z1GHZXvrPxR/R8Q2YrG8wBgdNvfPtXCFXDlW1FF2AFtORtA==
+"@aztec/simulator@3.0.0-devnet.6-patch.1":
+  version "3.0.0-devnet.6-patch.1"
+  resolved "https://registry.yarnpkg.com/@aztec/simulator/-/simulator-3.0.0-devnet.6-patch.1.tgz#0c22af0f6be531c8b32b0f735a3e8ae207530cb7"
+  integrity sha512-nDXLLCYMDVTCi8uUUBGO715f4Q+KyoKPa8p0bpJ/08y99aPT67BoouUJE0XXAv44MbQcLgt1SO0dwdW9Cc81Tg==
   dependencies:
-    "@aztec/constants" "3.0.0-devnet.20251212"
-    "@aztec/foundation" "3.0.0-devnet.20251212"
-    "@aztec/native" "3.0.0-devnet.20251212"
-    "@aztec/noir-acvm_js" "3.0.0-devnet.20251212"
-    "@aztec/noir-noirc_abi" "3.0.0-devnet.20251212"
-    "@aztec/noir-protocol-circuits-types" "3.0.0-devnet.20251212"
-    "@aztec/noir-types" "3.0.0-devnet.20251212"
-    "@aztec/protocol-contracts" "3.0.0-devnet.20251212"
-    "@aztec/stdlib" "3.0.0-devnet.20251212"
-    "@aztec/telemetry-client" "3.0.0-devnet.20251212"
-    "@aztec/world-state" "3.0.0-devnet.20251212"
+    "@aztec/constants" "3.0.0-devnet.6-patch.1"
+    "@aztec/foundation" "3.0.0-devnet.6-patch.1"
+    "@aztec/native" "3.0.0-devnet.6-patch.1"
+    "@aztec/noir-acvm_js" "3.0.0-devnet.6-patch.1"
+    "@aztec/noir-noirc_abi" "3.0.0-devnet.6-patch.1"
+    "@aztec/noir-protocol-circuits-types" "3.0.0-devnet.6-patch.1"
+    "@aztec/noir-types" "3.0.0-devnet.6-patch.1"
+    "@aztec/protocol-contracts" "3.0.0-devnet.6-patch.1"
+    "@aztec/stdlib" "3.0.0-devnet.6-patch.1"
+    "@aztec/telemetry-client" "3.0.0-devnet.6-patch.1"
+    "@aztec/world-state" "3.0.0-devnet.6-patch.1"
     lodash.clonedeep "^4.5.0"
     lodash.merge "^4.6.2"
     tslib "^2.4.0"
 
-"@aztec/stdlib@3.0.0-devnet.20251212":
-  version "3.0.0-devnet.20251212"
-  resolved "https://registry.yarnpkg.com/@aztec/stdlib/-/stdlib-3.0.0-devnet.20251212.tgz#e87ea64a15137aaa55395f30278ba184a3928f97"
-  integrity sha512-dynBZhet96Uq4xXM4oqRUcD/7E6pJXK3yVQH5cpCUEzk47vzDeQCdbRiIJJ+QEM5SVIjx2PG0fct1nFXcCD5Hw==
+"@aztec/stdlib@3.0.0-devnet.6-patch.1":
+  version "3.0.0-devnet.6-patch.1"
+  resolved "https://registry.yarnpkg.com/@aztec/stdlib/-/stdlib-3.0.0-devnet.6-patch.1.tgz#0f82be8011843165519293f11e9ec9c43bc86a5f"
+  integrity sha512-nljgFQ046BKWg10HTiYD/UjrC8rWs+8nRFWMVeAPrLiX0mWrjjMHkqag480U2ROO4YpdqqgbVujnNmQa/cLzuA==
   dependencies:
     "@aws-sdk/client-s3" "^3.892.0"
-    "@aztec/bb.js" "3.0.0-devnet.20251212"
-    "@aztec/blob-lib" "3.0.0-devnet.20251212"
-    "@aztec/constants" "3.0.0-devnet.20251212"
-    "@aztec/ethereum" "3.0.0-devnet.20251212"
-    "@aztec/foundation" "3.0.0-devnet.20251212"
-    "@aztec/l1-artifacts" "3.0.0-devnet.20251212"
-    "@aztec/noir-noirc_abi" "3.0.0-devnet.20251212"
+    "@aztec/bb.js" "3.0.0-devnet.6-patch.1"
+    "@aztec/blob-lib" "3.0.0-devnet.6-patch.1"
+    "@aztec/constants" "3.0.0-devnet.6-patch.1"
+    "@aztec/ethereum" "3.0.0-devnet.6-patch.1"
+    "@aztec/foundation" "3.0.0-devnet.6-patch.1"
+    "@aztec/l1-artifacts" "3.0.0-devnet.6-patch.1"
+    "@aztec/noir-noirc_abi" "3.0.0-devnet.6-patch.1"
     "@google-cloud/storage" "^7.15.0"
     axios "^1.12.0"
     json-stringify-deterministic "1.0.12"
@@ -929,13 +929,13 @@
     viem "npm:@aztec/viem@2.38.2"
     zod "^3.23.8"
 
-"@aztec/telemetry-client@3.0.0-devnet.20251212":
-  version "3.0.0-devnet.20251212"
-  resolved "https://registry.yarnpkg.com/@aztec/telemetry-client/-/telemetry-client-3.0.0-devnet.20251212.tgz#7cef701d20f1adcdde6508c1dc101a638e830db0"
-  integrity sha512-Q77CD74Y+aCiisqdXvitYF31/3N5No5CKSf5w/DsL5WKpyiIsW0fEM09QBIhEz3JUCh9J7jG4cz7PaNQ5xoyQg==
+"@aztec/telemetry-client@3.0.0-devnet.6-patch.1":
+  version "3.0.0-devnet.6-patch.1"
+  resolved "https://registry.yarnpkg.com/@aztec/telemetry-client/-/telemetry-client-3.0.0-devnet.6-patch.1.tgz#599032472c50ffe1d45641e9568ff1cae99c46b0"
+  integrity sha512-XZeLKSf2ws+2VEzGDESBkFo8kI9BGNTRXHpAJZ7NIFCbEGBwb44N0Rf8S8BBJgixARg7iUaiiFs2y2mBf3b2Gg==
   dependencies:
-    "@aztec/foundation" "3.0.0-devnet.20251212"
-    "@aztec/stdlib" "3.0.0-devnet.20251212"
+    "@aztec/foundation" "3.0.0-devnet.6-patch.1"
+    "@aztec/stdlib" "3.0.0-devnet.6-patch.1"
     "@opentelemetry/api" "^1.9.0"
     "@opentelemetry/api-logs" "^0.55.0"
     "@opentelemetry/core" "^1.28.0"
@@ -953,45 +953,45 @@
     prom-client "^15.1.3"
     viem "npm:@aztec/viem@2.38.2"
 
-"@aztec/test-wallet@3.0.0-devnet.20251212":
-  version "3.0.0-devnet.20251212"
-  resolved "https://registry.yarnpkg.com/@aztec/test-wallet/-/test-wallet-3.0.0-devnet.20251212.tgz#b72ec3502dc7361850a94c25684f167afa6a6322"
-  integrity sha512-f2rqo8YPOtPrDsPnjYFdYb8bg1uWYAQvtN+jYYTKT9m2EuqJ8e9urXbifG2Qpa4WkLzycYFbhO/lwwwnJ8OD8A==
+"@aztec/test-wallet@3.0.0-devnet.6-patch.1":
+  version "3.0.0-devnet.6-patch.1"
+  resolved "https://registry.yarnpkg.com/@aztec/test-wallet/-/test-wallet-3.0.0-devnet.6-patch.1.tgz#fc70b9c639ed77d1a04d449f2aaf36f5bfeee784"
+  integrity sha512-K9jZrWN2XKzLm9X3prLwuvNPFKf9q+jc6jnuesHAMDsLDMDjG5YYBlLfYYHsNI6DbpHT0CxGDgPFuK4qYB3Dqg==
   dependencies:
-    "@aztec/accounts" "3.0.0-devnet.20251212"
-    "@aztec/aztec.js" "3.0.0-devnet.20251212"
-    "@aztec/entrypoints" "3.0.0-devnet.20251212"
-    "@aztec/foundation" "3.0.0-devnet.20251212"
-    "@aztec/noir-contracts.js" "3.0.0-devnet.20251212"
-    "@aztec/pxe" "3.0.0-devnet.20251212"
-    "@aztec/stdlib" "3.0.0-devnet.20251212"
-    "@aztec/wallet-sdk" "3.0.0-devnet.20251212"
+    "@aztec/accounts" "3.0.0-devnet.6-patch.1"
+    "@aztec/aztec.js" "3.0.0-devnet.6-patch.1"
+    "@aztec/entrypoints" "3.0.0-devnet.6-patch.1"
+    "@aztec/foundation" "3.0.0-devnet.6-patch.1"
+    "@aztec/noir-contracts.js" "3.0.0-devnet.6-patch.1"
+    "@aztec/pxe" "3.0.0-devnet.6-patch.1"
+    "@aztec/stdlib" "3.0.0-devnet.6-patch.1"
+    "@aztec/wallet-sdk" "3.0.0-devnet.6-patch.1"
 
-"@aztec/wallet-sdk@3.0.0-devnet.20251212":
-  version "3.0.0-devnet.20251212"
-  resolved "https://registry.yarnpkg.com/@aztec/wallet-sdk/-/wallet-sdk-3.0.0-devnet.20251212.tgz#bd0e5c646582f8b73e93b6aa5c2748d1ea446f17"
-  integrity sha512-ZpH6cZgxON1S38dwKKkY2xDpjJ53G3AGOGYU4PqF6H1TXTISWxvrM/zCnt5JokGQtz+vDkze2A0rm/JtgVUebg==
+"@aztec/wallet-sdk@3.0.0-devnet.6-patch.1":
+  version "3.0.0-devnet.6-patch.1"
+  resolved "https://registry.yarnpkg.com/@aztec/wallet-sdk/-/wallet-sdk-3.0.0-devnet.6-patch.1.tgz#1ec5ac27f6d5b29758606457712c7966325b74a0"
+  integrity sha512-acshskh0gWYwanEDpc2lfwAuoexsf0halQsJRCFjMgkRW1nryEUefBGsRe0Ztq572OVNCpd8KpJRzDl4OcVjPg==
   dependencies:
-    "@aztec/aztec.js" "3.0.0-devnet.20251212"
-    "@aztec/constants" "3.0.0-devnet.20251212"
-    "@aztec/entrypoints" "3.0.0-devnet.20251212"
-    "@aztec/foundation" "3.0.0-devnet.20251212"
-    "@aztec/pxe" "3.0.0-devnet.20251212"
-    "@aztec/stdlib" "3.0.0-devnet.20251212"
+    "@aztec/aztec.js" "3.0.0-devnet.6-patch.1"
+    "@aztec/constants" "3.0.0-devnet.6-patch.1"
+    "@aztec/entrypoints" "3.0.0-devnet.6-patch.1"
+    "@aztec/foundation" "3.0.0-devnet.6-patch.1"
+    "@aztec/pxe" "3.0.0-devnet.6-patch.1"
+    "@aztec/stdlib" "3.0.0-devnet.6-patch.1"
 
-"@aztec/world-state@3.0.0-devnet.20251212":
-  version "3.0.0-devnet.20251212"
-  resolved "https://registry.yarnpkg.com/@aztec/world-state/-/world-state-3.0.0-devnet.20251212.tgz#a376363b92db3c37041611499f592849851d288a"
-  integrity sha512-YcivSND09IFwOJGuzd+KxCcey5voU0KkgDUvSXSv/l0OZQR3o1OBWO9in08GseF4FQI3SZSuLzM3hhuPwMPLgg==
+"@aztec/world-state@3.0.0-devnet.6-patch.1":
+  version "3.0.0-devnet.6-patch.1"
+  resolved "https://registry.yarnpkg.com/@aztec/world-state/-/world-state-3.0.0-devnet.6-patch.1.tgz#78b8cc83a67ca612d55e431219f2ac497ac4803e"
+  integrity sha512-6/svpdxdb/XkBGu+YH+EJZpnyCTyg4oZ31Mm1RsnYRUYz6gyZjh6w0CuiIPP3FOhnzfnvBCNrzcVK3apv7FImg==
   dependencies:
-    "@aztec/constants" "3.0.0-devnet.20251212"
-    "@aztec/foundation" "3.0.0-devnet.20251212"
-    "@aztec/kv-store" "3.0.0-devnet.20251212"
-    "@aztec/merkle-tree" "3.0.0-devnet.20251212"
-    "@aztec/native" "3.0.0-devnet.20251212"
-    "@aztec/protocol-contracts" "3.0.0-devnet.20251212"
-    "@aztec/stdlib" "3.0.0-devnet.20251212"
-    "@aztec/telemetry-client" "3.0.0-devnet.20251212"
+    "@aztec/constants" "3.0.0-devnet.6-patch.1"
+    "@aztec/foundation" "3.0.0-devnet.6-patch.1"
+    "@aztec/kv-store" "3.0.0-devnet.6-patch.1"
+    "@aztec/merkle-tree" "3.0.0-devnet.6-patch.1"
+    "@aztec/native" "3.0.0-devnet.6-patch.1"
+    "@aztec/protocol-contracts" "3.0.0-devnet.6-patch.1"
+    "@aztec/stdlib" "3.0.0-devnet.6-patch.1"
+    "@aztec/telemetry-client" "3.0.0-devnet.6-patch.1"
     tslib "^2.4.0"
     zod "^3.23.8"
 

--- a/prediction-market/Nargo.toml
+++ b/prediction-market/Nargo.toml
@@ -5,6 +5,6 @@ compiler_version = ">=0.25.0"
 type = "contract"
 
 [dependencies]
-aztec = { git = "https://github.com/AztecProtocol/aztec-packages/", tag = "v3.0.0-devnet.20251212", directory = "noir-projects/aztec-nr/aztec" }
-uint_note = { git = "https://github.com/AztecProtocol/aztec-packages/", tag = "v3.0.0-devnet.20251212", directory = "noir-projects/aztec-nr/uint-note" }
-balance_set = { git = "https://github.com/AztecProtocol/aztec-packages/", tag = "v3.0.0-devnet.20251212", directory = "noir-projects/aztec-nr/balance-set" }
+aztec = { git = "https://github.com/AztecProtocol/aztec-nr/", tag = "v3.0.0-devnet.6-patch.1", directory = "aztec" }
+uint_note = { git = "https://github.com/AztecProtocol/aztec-nr/", tag = "v3.0.0-devnet.6-patch.1", directory = "uint-note" }
+balance_set = { git = "https://github.com/AztecProtocol/aztec-nr/", tag = "v3.0.0-devnet.6-patch.1", directory = "balance-set" }

--- a/prediction-market/README.md
+++ b/prediction-market/README.md
@@ -92,7 +92,7 @@ const balance = await market.methods.get_collateral_balance(myAddress).simulate(
 ```bash
 # Install Aztec tools
 bash -i <(curl -s https://install.aztec.network)
-aztec-up 3.0.0-devnet.20251212
+aztec-up 3.0.0-devnet.6-patch.1
 
 # Install dependencies
 yarn install

--- a/prediction-market/package.json
+++ b/prediction-market/package.json
@@ -23,9 +23,9 @@
     "typescript": "^5.0.0"
   },
   "dependencies": {
-    "@aztec/accounts": "3.0.0-devnet.20251212",
-    "@aztec/aztec.js": "3.0.0-devnet.20251212",
-    "@aztec/pxe": "3.0.0-devnet.20251212",
-    "@aztec/test-wallet": "3.0.0-devnet.20251212"
+    "@aztec/accounts": "3.0.0-devnet.6-patch.1",
+    "@aztec/aztec.js": "3.0.0-devnet.6-patch.1",
+    "@aztec/pxe": "3.0.0-devnet.6-patch.1",
+    "@aztec/test-wallet": "3.0.0-devnet.6-patch.1"
   }
 }

--- a/prediction-market/yarn.lock
+++ b/prediction-market/yarn.lock
@@ -588,130 +588,133 @@
   resolved "https://registry.yarnpkg.com/@aws/lambda-invoke-store/-/lambda-invoke-store-0.2.2.tgz#b00f7d6aedfe832ef6c84488f3a422cce6a47efa"
   integrity sha512-C0NBLsIqzDIae8HFw9YIrIBsbc0xTiOtt7fAukGPnqQ/+zZNaq+4jhuccltK0QuWHBnNm/a6kLIRA6GFiM10eg==
 
-"@aztec/accounts@3.0.0-devnet.5":
-  version "3.0.0-devnet.5"
-  resolved "https://registry.yarnpkg.com/@aztec/accounts/-/accounts-3.0.0-devnet.5.tgz#44482486c15ede1834aa27ce80d6543c82f68dae"
-  integrity sha512-VEN4i5SjA2waCO2KRcGvRmv5n06i2dRlFmozSIVss0j8a1IRvr1PGCOsRK7/ymForcRmLnozM2kJXZySf12xCQ==
+"@aztec/accounts@3.0.0-devnet.6-patch.1":
+  version "3.0.0-devnet.6-patch.1"
+  resolved "https://registry.yarnpkg.com/@aztec/accounts/-/accounts-3.0.0-devnet.6-patch.1.tgz#05b44647c732e3deb723571e73c10a36d762c154"
+  integrity sha512-0iJN0t6AYgv6rxYjLSQvbwo5n8zEfJdwHoydIkqSbSLbymU5NoDnNB7jwl1omAmWqBAKN4hOr4p8Gh2ZldYIsQ==
   dependencies:
-    "@aztec/aztec.js" "3.0.0-devnet.5"
-    "@aztec/entrypoints" "3.0.0-devnet.5"
-    "@aztec/ethereum" "3.0.0-devnet.5"
-    "@aztec/foundation" "3.0.0-devnet.5"
-    "@aztec/stdlib" "3.0.0-devnet.5"
+    "@aztec/aztec.js" "3.0.0-devnet.6-patch.1"
+    "@aztec/entrypoints" "3.0.0-devnet.6-patch.1"
+    "@aztec/ethereum" "3.0.0-devnet.6-patch.1"
+    "@aztec/foundation" "3.0.0-devnet.6-patch.1"
+    "@aztec/stdlib" "3.0.0-devnet.6-patch.1"
     tslib "^2.4.0"
 
-"@aztec/aztec.js@3.0.0-devnet.5":
-  version "3.0.0-devnet.5"
-  resolved "https://registry.yarnpkg.com/@aztec/aztec.js/-/aztec.js-3.0.0-devnet.5.tgz#f9299b429051a3d44d73e8f0df4fdebd9d845596"
-  integrity sha512-imufeCwtwMslvLa1oUgV/NpFUjqmb/mnGLNmXoHx0vSwPWG5SIyorxkzSvenuYeF3NVo++LJaW9Ng4lzRj0CiA==
+"@aztec/aztec.js@3.0.0-devnet.6-patch.1":
+  version "3.0.0-devnet.6-patch.1"
+  resolved "https://registry.yarnpkg.com/@aztec/aztec.js/-/aztec.js-3.0.0-devnet.6-patch.1.tgz#cbf2c015c76a7e346044cf6a0b7724f1a85d661f"
+  integrity sha512-vPba9qQg1IUyg9aTyzEJfHwtwb7guCF2BiBAwnqPKkhoSG06CoDHQfU7T+JqxY9QpdWqDGUSfvDCr5wRFlEL0g==
   dependencies:
-    "@aztec/constants" "3.0.0-devnet.5"
-    "@aztec/entrypoints" "3.0.0-devnet.5"
-    "@aztec/ethereum" "3.0.0-devnet.5"
-    "@aztec/foundation" "3.0.0-devnet.5"
-    "@aztec/l1-artifacts" "3.0.0-devnet.5"
-    "@aztec/protocol-contracts" "3.0.0-devnet.5"
-    "@aztec/stdlib" "3.0.0-devnet.5"
+    "@aztec/constants" "3.0.0-devnet.6-patch.1"
+    "@aztec/entrypoints" "3.0.0-devnet.6-patch.1"
+    "@aztec/ethereum" "3.0.0-devnet.6-patch.1"
+    "@aztec/foundation" "3.0.0-devnet.6-patch.1"
+    "@aztec/l1-artifacts" "3.0.0-devnet.6-patch.1"
+    "@aztec/protocol-contracts" "3.0.0-devnet.6-patch.1"
+    "@aztec/stdlib" "3.0.0-devnet.6-patch.1"
     axios "^1.12.0"
     tslib "^2.4.0"
-    viem "npm:@spalladino/viem@2.38.2-eip7594.0"
+    viem "npm:@aztec/viem@2.38.2"
     zod "^3.23.8"
 
-"@aztec/bb-prover@3.0.0-devnet.5":
-  version "3.0.0-devnet.5"
-  resolved "https://registry.yarnpkg.com/@aztec/bb-prover/-/bb-prover-3.0.0-devnet.5.tgz#cb058e2a15fb730801be73494a546370ea2df531"
-  integrity sha512-Q/9MrINagHGI5TwqG6IF58wC/ItS68MPKniRCBShvVfDDqAJp/Sv9eJw0bshEqj+xGPGeu5zpha5J22TEUABAA==
+"@aztec/bb-prover@3.0.0-devnet.6-patch.1":
+  version "3.0.0-devnet.6-patch.1"
+  resolved "https://registry.yarnpkg.com/@aztec/bb-prover/-/bb-prover-3.0.0-devnet.6-patch.1.tgz#22155bbba2571eddf2cbc0cf0eccc3000224ce95"
+  integrity sha512-SMuVhCN6iA4WJOdk2Aj1iuK/+6I27cWCu0V/rm1ZQyNEryPteIXKnXleG5HWSZ+MRIngOAut+hT8cFhHRSfrLA==
   dependencies:
-    "@aztec/bb.js" "3.0.0-devnet.5"
-    "@aztec/constants" "3.0.0-devnet.5"
-    "@aztec/foundation" "3.0.0-devnet.5"
-    "@aztec/noir-noirc_abi" "3.0.0-devnet.5"
-    "@aztec/noir-protocol-circuits-types" "3.0.0-devnet.5"
-    "@aztec/noir-types" "3.0.0-devnet.5"
-    "@aztec/simulator" "3.0.0-devnet.5"
-    "@aztec/stdlib" "3.0.0-devnet.5"
-    "@aztec/telemetry-client" "3.0.0-devnet.5"
-    "@aztec/world-state" "3.0.0-devnet.5"
+    "@aztec/bb.js" "3.0.0-devnet.6-patch.1"
+    "@aztec/constants" "3.0.0-devnet.6-patch.1"
+    "@aztec/foundation" "3.0.0-devnet.6-patch.1"
+    "@aztec/noir-noirc_abi" "3.0.0-devnet.6-patch.1"
+    "@aztec/noir-protocol-circuits-types" "3.0.0-devnet.6-patch.1"
+    "@aztec/noir-types" "3.0.0-devnet.6-patch.1"
+    "@aztec/simulator" "3.0.0-devnet.6-patch.1"
+    "@aztec/stdlib" "3.0.0-devnet.6-patch.1"
+    "@aztec/telemetry-client" "3.0.0-devnet.6-patch.1"
+    "@aztec/world-state" "3.0.0-devnet.6-patch.1"
     commander "^12.1.0"
     pako "^2.1.0"
     source-map-support "^0.5.21"
     tslib "^2.4.0"
 
-"@aztec/bb.js@3.0.0-devnet.5":
-  version "3.0.0-devnet.5"
-  resolved "https://registry.yarnpkg.com/@aztec/bb.js/-/bb.js-3.0.0-devnet.5.tgz#943def962954647e88fe1dc04c431c9967d55b22"
-  integrity sha512-PreVW5HaIZC0OhXDdLHFxyUo2n71amChLh58MPzca9L1bex+g4naAd+7z6IepSGY2eQT8dWLhuhn7DYnBA3TYQ==
+"@aztec/bb.js@3.0.0-devnet.6-patch.1":
+  version "3.0.0-devnet.6-patch.1"
+  resolved "https://registry.yarnpkg.com/@aztec/bb.js/-/bb.js-3.0.0-devnet.6-patch.1.tgz#6781fa91d7faeb5a3bc1e3f8fabc4ddd4a9bb92c"
+  integrity sha512-ULRG/Ky5h2Lpaw4lXjkEzJdQVgfCFhBY9Fb0mL+Y+yC+thi2T5rQmmAwh5Qmr7F+KwKcozgtryV7Ook3rVjbhA==
   dependencies:
     comlink "^4.4.1"
     commander "^12.1.0"
     idb-keyval "^6.2.1"
     msgpackr "^1.11.2"
     pako "^2.1.0"
-    pino "^9.5.0"
     tslib "^2.4.0"
 
-"@aztec/blob-lib@3.0.0-devnet.5":
-  version "3.0.0-devnet.5"
-  resolved "https://registry.yarnpkg.com/@aztec/blob-lib/-/blob-lib-3.0.0-devnet.5.tgz#698cd11f67a8f234af914e252d3fecfb9b0067bb"
-  integrity sha512-Vf+EGDbUAXpIBXx1DR5vdBSxPf7fjDV5NIE/Ds+UMFxfEHoHNk4lwgFc9ERWBh81L/uDTuGgmZn4X009p66Uug==
+"@aztec/blob-lib@3.0.0-devnet.6-patch.1":
+  version "3.0.0-devnet.6-patch.1"
+  resolved "https://registry.yarnpkg.com/@aztec/blob-lib/-/blob-lib-3.0.0-devnet.6-patch.1.tgz#ca476037b413acbe75766785e5b26da09afe8c54"
+  integrity sha512-l3YxkxfAm3RF7016QHXFxlQF58wgSpI0u7xfe6NpupO7k3gnCOrLm8p6GcBGcIoTIcf5GJzK2QfZvBsX+WVZHw==
   dependencies:
-    "@aztec/constants" "3.0.0-devnet.5"
-    "@aztec/foundation" "3.0.0-devnet.5"
+    "@aztec/constants" "3.0.0-devnet.6-patch.1"
+    "@aztec/foundation" "3.0.0-devnet.6-patch.1"
     "@crate-crypto/node-eth-kzg" "^0.10.0"
     tslib "^2.4.0"
 
-"@aztec/builder@3.0.0-devnet.5":
-  version "3.0.0-devnet.5"
-  resolved "https://registry.yarnpkg.com/@aztec/builder/-/builder-3.0.0-devnet.5.tgz#9b95bad40e038a6f464c8518d9261d5d4d2f54de"
-  integrity sha512-Mi0/pF10uPSZnX3yyqBANCv3+XqHipJmUtV8cUV4jJn158rJ00hL0846Nqy7Q/HMR84VduJXVroTm0u2mwt2Hg==
+"@aztec/builder@3.0.0-devnet.6-patch.1":
+  version "3.0.0-devnet.6-patch.1"
+  resolved "https://registry.yarnpkg.com/@aztec/builder/-/builder-3.0.0-devnet.6-patch.1.tgz#a25cd90e83e8c2595c6a3c0440c683e42e258af2"
+  integrity sha512-IPBXJVhDu3T3K59uVCBX/jK+/Wkn5Z0coBzlcRQkr6puLv8sZod8vPwPrEGeWxOYz6VZN7JUkJup5ZqKR2vFgg==
   dependencies:
-    "@aztec/foundation" "3.0.0-devnet.5"
-    "@aztec/stdlib" "3.0.0-devnet.5"
+    "@aztec/foundation" "3.0.0-devnet.6-patch.1"
+    "@aztec/stdlib" "3.0.0-devnet.6-patch.1"
     commander "^12.1.0"
 
-"@aztec/constants@3.0.0-devnet.5":
-  version "3.0.0-devnet.5"
-  resolved "https://registry.yarnpkg.com/@aztec/constants/-/constants-3.0.0-devnet.5.tgz#c3f27558400b8a6ff267f5fd354612d23e66eab5"
-  integrity sha512-+d1hHUtnSuGV/w1LuVFSuSznFO2sgrxn9IOr/mucfoqNoUr0zAC1GIMzWgUbMxckja8sQs8Jh2AiuyG8+QIZVw==
+"@aztec/constants@3.0.0-devnet.6-patch.1":
+  version "3.0.0-devnet.6-patch.1"
+  resolved "https://registry.yarnpkg.com/@aztec/constants/-/constants-3.0.0-devnet.6-patch.1.tgz#c0588e4039de977949b997cb65f45721539cf6bd"
+  integrity sha512-YKH/JQ+Qpd8X9xtWwTBc1yVChjfO9yKFPH2x/LIll89rkPT9GU3OKQeKpnXOKlnC/2IWW2ZExASfwttp8TWtXg==
   dependencies:
+    "@aztec/foundation" "3.0.0-devnet.6-patch.1"
     tslib "^2.4.0"
 
-"@aztec/entrypoints@3.0.0-devnet.5":
-  version "3.0.0-devnet.5"
-  resolved "https://registry.yarnpkg.com/@aztec/entrypoints/-/entrypoints-3.0.0-devnet.5.tgz#eb53e873134fbd683a3a9893d4d99171c7a9eae1"
-  integrity sha512-cDFSuGgCWAz5oBPL7JLw+w/jANHrOhEQ3cs7BxZHpz8FNEM5g48Ks69kPaV7pD1DQ+7GQWmRQLf+xxQV/3wL4Q==
+"@aztec/entrypoints@3.0.0-devnet.6-patch.1":
+  version "3.0.0-devnet.6-patch.1"
+  resolved "https://registry.yarnpkg.com/@aztec/entrypoints/-/entrypoints-3.0.0-devnet.6-patch.1.tgz#ade9929ab6351c990844649b62a2ccc7ce474400"
+  integrity sha512-rHVRJGk7rxw16rxxQzfojnYjqK0zBtQVghLj1+4p91looN0T4xS8sEXr4jCGPG78uj3NLkYLuPQCQCDVmWXVcA==
   dependencies:
-    "@aztec/constants" "3.0.0-devnet.5"
-    "@aztec/foundation" "3.0.0-devnet.5"
-    "@aztec/protocol-contracts" "3.0.0-devnet.5"
-    "@aztec/stdlib" "3.0.0-devnet.5"
+    "@aztec/constants" "3.0.0-devnet.6-patch.1"
+    "@aztec/foundation" "3.0.0-devnet.6-patch.1"
+    "@aztec/protocol-contracts" "3.0.0-devnet.6-patch.1"
+    "@aztec/stdlib" "3.0.0-devnet.6-patch.1"
     tslib "^2.4.0"
+    zod "^3.23.8"
 
-"@aztec/ethereum@3.0.0-devnet.5":
-  version "3.0.0-devnet.5"
-  resolved "https://registry.yarnpkg.com/@aztec/ethereum/-/ethereum-3.0.0-devnet.5.tgz#79c1e22c64ea4a89cee2640865970b7e6af13b72"
-  integrity sha512-4dl6BO8ajpMFKSWdjZvn9lk5QfPLEOEsJ01xgZJX65wBm5Qde86irF5/1oXhjaz5lpaBm9jKD8+eTB8X8Lu31w==
+"@aztec/ethereum@3.0.0-devnet.6-patch.1":
+  version "3.0.0-devnet.6-patch.1"
+  resolved "https://registry.yarnpkg.com/@aztec/ethereum/-/ethereum-3.0.0-devnet.6-patch.1.tgz#16a1f80facf54441b4f606d01fa0a83103f6d74f"
+  integrity sha512-J1QxJFpYIcWw3Se8eVBWMTvZsGTngwz7h6wgWEkUj2noFe2zPpvASGe389rrHPqqdsQ70yZ92kDaHQ2KyhDzLw==
   dependencies:
-    "@aztec/blob-lib" "3.0.0-devnet.5"
-    "@aztec/constants" "3.0.0-devnet.5"
-    "@aztec/foundation" "3.0.0-devnet.5"
-    "@aztec/l1-artifacts" "3.0.0-devnet.5"
+    "@aztec/blob-lib" "3.0.0-devnet.6-patch.1"
+    "@aztec/constants" "3.0.0-devnet.6-patch.1"
+    "@aztec/foundation" "3.0.0-devnet.6-patch.1"
+    "@aztec/l1-artifacts" "3.0.0-devnet.6-patch.1"
     "@viem/anvil" "^0.0.10"
     dotenv "^16.0.3"
     lodash.chunk "^4.2.0"
     lodash.pickby "^4.5.0"
     tslib "^2.4.0"
-    viem "npm:@spalladino/viem@2.38.2-eip7594.0"
+    viem "npm:@aztec/viem@2.38.2"
     zod "^3.23.8"
 
-"@aztec/foundation@3.0.0-devnet.5":
-  version "3.0.0-devnet.5"
-  resolved "https://registry.yarnpkg.com/@aztec/foundation/-/foundation-3.0.0-devnet.5.tgz#f6c98b074cdf26565c61a55d5182f5ca5a8dd919"
-  integrity sha512-Ks9DFE8K01wObwJdsTMYSC84cSQCgbBGyfLB7fnH/CAx2Th9wxPzeLMhmGNQEBLtG4RARdkiAbMUAjlRHI1yEw==
+"@aztec/foundation@3.0.0-devnet.6-patch.1":
+  version "3.0.0-devnet.6-patch.1"
+  resolved "https://registry.yarnpkg.com/@aztec/foundation/-/foundation-3.0.0-devnet.6-patch.1.tgz#feacdef89029695ccec0fa7d419faf595d5ab27a"
+  integrity sha512-8oNaZPdU0vMRPxHZzwkOfEPsC9IRswP1WXCqxgdQHYSufYNxNrDZ7aVQpuI0sPkA3BsCXzPb/tQTgD+E2WoYEQ==
   dependencies:
-    "@aztec/bb.js" "3.0.0-devnet.5"
+    "@aztec/bb.js" "3.0.0-devnet.6-patch.1"
     "@koa/cors" "^5.0.0"
     "@noble/curves" "=1.7.0"
+    "@noble/hashes" "^1.6.1"
+    "@scure/bip39" "^2.0.1"
     bn.js "^5.2.1"
     colorette "^2.0.20"
     detect-node "^2.1.0"
@@ -730,178 +733,180 @@
     undici "^5.28.5"
     zod "^3.23.8"
 
-"@aztec/key-store@3.0.0-devnet.5":
-  version "3.0.0-devnet.5"
-  resolved "https://registry.yarnpkg.com/@aztec/key-store/-/key-store-3.0.0-devnet.5.tgz#bfe77457a027f4aaef154c78751b44f42cf50ab7"
-  integrity sha512-GabVDXsoPwb8YUN2AVq0pBvwiUPo9F3clvb8GpQuzvkDtLc0O9EPstxqEeHoaQTI2lQi5+KJi27kNTAiyeGiCw==
+"@aztec/key-store@3.0.0-devnet.6-patch.1":
+  version "3.0.0-devnet.6-patch.1"
+  resolved "https://registry.yarnpkg.com/@aztec/key-store/-/key-store-3.0.0-devnet.6-patch.1.tgz#962c91aa606131a6e38ab2845049bd07d7e46781"
+  integrity sha512-LV3JhRG0RW5O4CK5dB4MEOQQHM+N6HwHeQrJG9tZr5P52GzwT7PlBPmopzuq/iKIh48MNizfMTux5681UqBe2Q==
   dependencies:
-    "@aztec/constants" "3.0.0-devnet.5"
-    "@aztec/foundation" "3.0.0-devnet.5"
-    "@aztec/kv-store" "3.0.0-devnet.5"
-    "@aztec/stdlib" "3.0.0-devnet.5"
+    "@aztec/constants" "3.0.0-devnet.6-patch.1"
+    "@aztec/foundation" "3.0.0-devnet.6-patch.1"
+    "@aztec/kv-store" "3.0.0-devnet.6-patch.1"
+    "@aztec/stdlib" "3.0.0-devnet.6-patch.1"
     tslib "^2.4.0"
 
-"@aztec/kv-store@3.0.0-devnet.5":
-  version "3.0.0-devnet.5"
-  resolved "https://registry.yarnpkg.com/@aztec/kv-store/-/kv-store-3.0.0-devnet.5.tgz#204c49896090c3f6278c7b6ba4dfb482613fe0e2"
-  integrity sha512-qGXZm4P8qNTICNmUAAzBUdxgxB5YU+31mPWXtWLrVNJNVmshQnV7h/AMESmgUlb6fAtWyLyZMjl/QrjSTpX9ig==
+"@aztec/kv-store@3.0.0-devnet.6-patch.1":
+  version "3.0.0-devnet.6-patch.1"
+  resolved "https://registry.yarnpkg.com/@aztec/kv-store/-/kv-store-3.0.0-devnet.6-patch.1.tgz#19850f5423a7d45d59656a50e57bad478599fe2c"
+  integrity sha512-Y3hMLidonMlN3eC/Blc+o6dN9VY+byLJsPXvNu+snGc6QR8rPw2x+vM/+QInsx9AFoIRfDjZU+64QMLKS4bizw==
   dependencies:
-    "@aztec/ethereum" "3.0.0-devnet.5"
-    "@aztec/foundation" "3.0.0-devnet.5"
-    "@aztec/native" "3.0.0-devnet.5"
-    "@aztec/stdlib" "3.0.0-devnet.5"
+    "@aztec/constants" "3.0.0-devnet.6-patch.1"
+    "@aztec/ethereum" "3.0.0-devnet.6-patch.1"
+    "@aztec/foundation" "3.0.0-devnet.6-patch.1"
+    "@aztec/native" "3.0.0-devnet.6-patch.1"
+    "@aztec/stdlib" "3.0.0-devnet.6-patch.1"
     idb "^8.0.0"
     lmdb "^3.2.0"
     msgpackr "^1.11.2"
     ohash "^2.0.11"
     ordered-binary "^1.5.3"
 
-"@aztec/l1-artifacts@3.0.0-devnet.5":
-  version "3.0.0-devnet.5"
-  resolved "https://registry.yarnpkg.com/@aztec/l1-artifacts/-/l1-artifacts-3.0.0-devnet.5.tgz#ba62709f88d768225f3d68cec5718665e2c5e5a2"
-  integrity sha512-a41fELYCc8wRRkD98wvJX+2HQWf8tE/sZQIQpHf5j/w1vrcoPoBkwysSoFzVJ4zEMM3Umj8VGkzBXfVaj8HtvA==
+"@aztec/l1-artifacts@3.0.0-devnet.6-patch.1":
+  version "3.0.0-devnet.6-patch.1"
+  resolved "https://registry.yarnpkg.com/@aztec/l1-artifacts/-/l1-artifacts-3.0.0-devnet.6-patch.1.tgz#fb017bcf65cfa9a9610b64ad0dcc7ff4fd46b0b2"
+  integrity sha512-aO01TaullALg6Mn/GK/HgB9AB+8mxyrQi7X9It/i2u+SA8UiIQuwoBzr3uAA1hsWnRCSD+M7RikMBvVmVDlYkg==
   dependencies:
     tslib "^2.4.0"
 
-"@aztec/merkle-tree@3.0.0-devnet.5":
-  version "3.0.0-devnet.5"
-  resolved "https://registry.yarnpkg.com/@aztec/merkle-tree/-/merkle-tree-3.0.0-devnet.5.tgz#4a8d1bb66389ba912ec9606f0dd05498703c1e2a"
-  integrity sha512-AgFukgx7nv89S4zfoRkGWAmLK+Mx5IEwnJsoTj1Hl57+62VrT5uSbLGQAdiukIfX2iay+B+9Kv2oTybIU/SKyg==
+"@aztec/merkle-tree@3.0.0-devnet.6-patch.1":
+  version "3.0.0-devnet.6-patch.1"
+  resolved "https://registry.yarnpkg.com/@aztec/merkle-tree/-/merkle-tree-3.0.0-devnet.6-patch.1.tgz#df973c1eea7ff561fc6b6545575df7813d32f10e"
+  integrity sha512-u6jt+4ATePLnCzACe1VGNYEjbRKDj19xgLtVa+nzcBBO527UIueKxQxjPZ8j9yMcLPGrSvDTdBqaOdm7uWPI4Q==
   dependencies:
-    "@aztec/foundation" "3.0.0-devnet.5"
-    "@aztec/kv-store" "3.0.0-devnet.5"
-    "@aztec/stdlib" "3.0.0-devnet.5"
+    "@aztec/foundation" "3.0.0-devnet.6-patch.1"
+    "@aztec/kv-store" "3.0.0-devnet.6-patch.1"
+    "@aztec/stdlib" "3.0.0-devnet.6-patch.1"
     sha256 "^0.2.0"
     tslib "^2.4.0"
 
-"@aztec/native@3.0.0-devnet.5":
-  version "3.0.0-devnet.5"
-  resolved "https://registry.yarnpkg.com/@aztec/native/-/native-3.0.0-devnet.5.tgz#2b8ad2b4527d406ec37c5c5ed0572e047919aa77"
-  integrity sha512-psF9eggbvW/KROQKpBp8Bbok47kh/LjKefKw2My7WzW88hQUMbYpEJK0C8lgmMN6clMEzFjIPL9zY81b2hk8LA==
+"@aztec/native@3.0.0-devnet.6-patch.1":
+  version "3.0.0-devnet.6-patch.1"
+  resolved "https://registry.yarnpkg.com/@aztec/native/-/native-3.0.0-devnet.6-patch.1.tgz#601c5bac626ea5fd60d45820205ec4b54c67f9c8"
+  integrity sha512-UNTdTD/sKJFzCjFjUcpX3g1ElxyIIDkkaMJek6CCb1rsXVtALgIx6K7QhRq26hkUPgS0pBpFPgznFOvh1bsE8w==
   dependencies:
-    "@aztec/foundation" "3.0.0-devnet.5"
+    "@aztec/bb.js" "3.0.0-devnet.6-patch.1"
+    "@aztec/foundation" "3.0.0-devnet.6-patch.1"
     msgpackr "^1.11.2"
 
-"@aztec/noir-acvm_js@3.0.0-devnet.5":
-  version "3.0.0-devnet.5"
-  resolved "https://registry.yarnpkg.com/@aztec/noir-acvm_js/-/noir-acvm_js-3.0.0-devnet.5.tgz#12211c89b4f799620ef29e3839a89c6b2dc20822"
-  integrity sha512-FTGxNN2MM3n/gxlNUarQSh690mo7yigFIJi+nnanbZkrBYBSdnddiC9Bn6yL9hxRSIyXBuLzT01GwxzDwZ75zA==
+"@aztec/noir-acvm_js@3.0.0-devnet.6-patch.1":
+  version "3.0.0-devnet.6-patch.1"
+  resolved "https://registry.yarnpkg.com/@aztec/noir-acvm_js/-/noir-acvm_js-3.0.0-devnet.6-patch.1.tgz#c6930c121c2a186cb7a071d46ff59b1ddda97da0"
+  integrity sha512-gJTPvM2bDzj+sVH5gmWgBo0tNyaecWyXmYwZCP4Cz5DtwfN7bcT4JAmjLex0u85i6rpJ+ij9ayPB8msqhvLJSw==
 
-"@aztec/noir-contracts.js@3.0.0-devnet.5":
-  version "3.0.0-devnet.5"
-  resolved "https://registry.yarnpkg.com/@aztec/noir-contracts.js/-/noir-contracts.js-3.0.0-devnet.5.tgz#11f41d55a4b517ac6ed73bc1e92fc37e5a850901"
-  integrity sha512-NkH0sz4cCmZoZaw/ZXdoGZUFQZyt2Gk6A+Im3pYoy/Fug07pR/7vMMzMpyWm/i4Jr1qE0LcMGb0uqXHtuzK5jg==
+"@aztec/noir-contracts.js@3.0.0-devnet.6-patch.1":
+  version "3.0.0-devnet.6-patch.1"
+  resolved "https://registry.yarnpkg.com/@aztec/noir-contracts.js/-/noir-contracts.js-3.0.0-devnet.6-patch.1.tgz#b9fdfec34de536ae579e3481177a046c27bf3598"
+  integrity sha512-GP1VX+qm5bkSsGpeekCWaLOAoMPFqpckx/WIqAyxJLlSTS7QuvANEulGJI22IBhktu133CtXXfzjATHPEGbN4g==
   dependencies:
-    "@aztec/aztec.js" "3.0.0-devnet.5"
+    "@aztec/aztec.js" "3.0.0-devnet.6-patch.1"
     tslib "^2.4.0"
 
-"@aztec/noir-noir_codegen@3.0.0-devnet.5":
-  version "3.0.0-devnet.5"
-  resolved "https://registry.yarnpkg.com/@aztec/noir-noir_codegen/-/noir-noir_codegen-3.0.0-devnet.5.tgz#4d4db4795bcbb72e72808658ed1e16bf887cbcaf"
-  integrity sha512-xOhoWvjxEn9DMgIyCbL6pV2xGHLupeuqjB6nCTl3PF/R5iynknPOehWG2gptCIVa/zO+m8LH8USlC9jjgrjG3Q==
+"@aztec/noir-noir_codegen@3.0.0-devnet.6-patch.1":
+  version "3.0.0-devnet.6-patch.1"
+  resolved "https://registry.yarnpkg.com/@aztec/noir-noir_codegen/-/noir-noir_codegen-3.0.0-devnet.6-patch.1.tgz#d7d614cb2cb828766977298076d8c3c48da95e16"
+  integrity sha512-dTvCSdNhSavN5vQ4rBZjD5A2mTgwnRXlNM4wOfJgk1bZEeuapJpD1bc98nV5e4a8C/G0TRgQT7CaxbrHluDdpw==
   dependencies:
-    "@aztec/noir-types" "3.0.0-devnet.5"
+    "@aztec/noir-types" "3.0.0-devnet.6-patch.1"
     glob "^11.0.3"
     ts-command-line-args "^2.5.1"
 
-"@aztec/noir-noirc_abi@3.0.0-devnet.5":
-  version "3.0.0-devnet.5"
-  resolved "https://registry.yarnpkg.com/@aztec/noir-noirc_abi/-/noir-noirc_abi-3.0.0-devnet.5.tgz#a2e826e9c2c5ed4499bd6209e982093c01c8e73c"
-  integrity sha512-Ve7DeT69Q45VayP+H0mzOvleNwS5UL7wqnEh3YZ6cpMPuCQKl5BSUiSwHhFyfI/6B/4JDVh4r4/ujArTBG4YPw==
+"@aztec/noir-noirc_abi@3.0.0-devnet.6-patch.1":
+  version "3.0.0-devnet.6-patch.1"
+  resolved "https://registry.yarnpkg.com/@aztec/noir-noirc_abi/-/noir-noirc_abi-3.0.0-devnet.6-patch.1.tgz#9cc1a1ebbce77f74a9c08d587c9363bd28c99b36"
+  integrity sha512-+J9StgFWBSi+zhGTmXXNbe3LV3lJ7FC4nmwQP6VENVLzoo1icT6S77N0xrfbcHCbdqmzw8FtKz0BR69VuXdChQ==
   dependencies:
-    "@aztec/noir-types" "3.0.0-devnet.5"
+    "@aztec/noir-types" "3.0.0-devnet.6-patch.1"
 
-"@aztec/noir-protocol-circuits-types@3.0.0-devnet.5":
-  version "3.0.0-devnet.5"
-  resolved "https://registry.yarnpkg.com/@aztec/noir-protocol-circuits-types/-/noir-protocol-circuits-types-3.0.0-devnet.5.tgz#0edf6bba41958ea0c87de6ff4c760127abc355e7"
-  integrity sha512-iv4MytPVLoaiLSy68LM1ztqRQ/N1dYITel9tUJqf2T04qgHJcraM+5tQz3xLaCvUP1Dax1l129ny7JX/GletNg==
+"@aztec/noir-protocol-circuits-types@3.0.0-devnet.6-patch.1":
+  version "3.0.0-devnet.6-patch.1"
+  resolved "https://registry.yarnpkg.com/@aztec/noir-protocol-circuits-types/-/noir-protocol-circuits-types-3.0.0-devnet.6-patch.1.tgz#1abd030097cb9540d4bee70d8d133a3c5a587945"
+  integrity sha512-/e8nlQjsZIE1OKE53zlH8EJUkw24/IEZ3Zsj4HNoSQvKz63Zu0yoNrTst02owUYqTprrDuFj5YL8qouTo3UsXA==
   dependencies:
-    "@aztec/blob-lib" "3.0.0-devnet.5"
-    "@aztec/constants" "3.0.0-devnet.5"
-    "@aztec/foundation" "3.0.0-devnet.5"
-    "@aztec/noir-acvm_js" "3.0.0-devnet.5"
-    "@aztec/noir-noir_codegen" "3.0.0-devnet.5"
-    "@aztec/noir-noirc_abi" "3.0.0-devnet.5"
-    "@aztec/noir-types" "3.0.0-devnet.5"
-    "@aztec/stdlib" "3.0.0-devnet.5"
+    "@aztec/blob-lib" "3.0.0-devnet.6-patch.1"
+    "@aztec/constants" "3.0.0-devnet.6-patch.1"
+    "@aztec/foundation" "3.0.0-devnet.6-patch.1"
+    "@aztec/noir-acvm_js" "3.0.0-devnet.6-patch.1"
+    "@aztec/noir-noir_codegen" "3.0.0-devnet.6-patch.1"
+    "@aztec/noir-noirc_abi" "3.0.0-devnet.6-patch.1"
+    "@aztec/noir-types" "3.0.0-devnet.6-patch.1"
+    "@aztec/stdlib" "3.0.0-devnet.6-patch.1"
     change-case "^5.4.4"
     tslib "^2.4.0"
 
-"@aztec/noir-types@3.0.0-devnet.5":
-  version "3.0.0-devnet.5"
-  resolved "https://registry.yarnpkg.com/@aztec/noir-types/-/noir-types-3.0.0-devnet.5.tgz#6a0979364c7bd829f8683d77c43b3f91bf12707e"
-  integrity sha512-MRZ5bS8khyXcT6p9ptOBDIfFOl0f7RFjclthbMrJ/q0B1b2VK3bs6k3iTgbxFQz5y3Ly2+eaoCZTcCujXbl/sg==
+"@aztec/noir-types@3.0.0-devnet.6-patch.1":
+  version "3.0.0-devnet.6-patch.1"
+  resolved "https://registry.yarnpkg.com/@aztec/noir-types/-/noir-types-3.0.0-devnet.6-patch.1.tgz#ce91b70427983bf32bb013d6c86b0b2e348956c3"
+  integrity sha512-zj7/ERBvTcnypoytwk4RBiN4mBe1kRVZJpd9byUPc5p9vVqi2uYkbaLa1JpjwyKShItWXU6TXv6C8V23jj5mGA==
 
-"@aztec/protocol-contracts@3.0.0-devnet.5":
-  version "3.0.0-devnet.5"
-  resolved "https://registry.yarnpkg.com/@aztec/protocol-contracts/-/protocol-contracts-3.0.0-devnet.5.tgz#06c78908dfeae74fc0f58c635f653e002b2547ce"
-  integrity sha512-ep292wqj81Bz5Nm6QIAYAVLcoYRev+PPB4aBSTFIDzyPBwr6zFeJNPmeUxenxivJrHeSsNmX0nivQnx8Hi8O1w==
+"@aztec/protocol-contracts@3.0.0-devnet.6-patch.1":
+  version "3.0.0-devnet.6-patch.1"
+  resolved "https://registry.yarnpkg.com/@aztec/protocol-contracts/-/protocol-contracts-3.0.0-devnet.6-patch.1.tgz#b5a79b19041593744d776a0adb9c0e1f99d50ca7"
+  integrity sha512-QbpoSNLZ54xzAmeen3t+oJEKoeoqD84mrP+ooFgLNPwuXAU48BP5Otq3aZIycIfTcjXnjIhORzLURX0ftU3sKg==
   dependencies:
-    "@aztec/constants" "3.0.0-devnet.5"
-    "@aztec/foundation" "3.0.0-devnet.5"
-    "@aztec/stdlib" "3.0.0-devnet.5"
+    "@aztec/constants" "3.0.0-devnet.6-patch.1"
+    "@aztec/foundation" "3.0.0-devnet.6-patch.1"
+    "@aztec/stdlib" "3.0.0-devnet.6-patch.1"
     lodash.chunk "^4.2.0"
     lodash.omit "^4.5.0"
     tslib "^2.4.0"
 
-"@aztec/pxe@3.0.0-devnet.5":
-  version "3.0.0-devnet.5"
-  resolved "https://registry.yarnpkg.com/@aztec/pxe/-/pxe-3.0.0-devnet.5.tgz#07a95197c0402cdd5b2c780ac1b735bb635d892e"
-  integrity sha512-0/D4yXN+y3Kyznoc9heOk2faqvK38PHbVDkAmoRtWePjqMrkvvQaH/XXmS+jnJTnpZ/cE4H6o5HdP7kgxdjQ7Q==
+"@aztec/pxe@3.0.0-devnet.6-patch.1":
+  version "3.0.0-devnet.6-patch.1"
+  resolved "https://registry.yarnpkg.com/@aztec/pxe/-/pxe-3.0.0-devnet.6-patch.1.tgz#996f07b034f8f97a254ed4d5bc8814e339f9e709"
+  integrity sha512-ugKffEjNH+U6EfkVuXceozQhmbHgCtLmNx2Jxl02hzW44/41lmL05zAHXCL5IKi+5NfyaRmMjxFJ898jXKa8Lw==
   dependencies:
-    "@aztec/bb-prover" "3.0.0-devnet.5"
-    "@aztec/bb.js" "3.0.0-devnet.5"
-    "@aztec/builder" "3.0.0-devnet.5"
-    "@aztec/constants" "3.0.0-devnet.5"
-    "@aztec/ethereum" "3.0.0-devnet.5"
-    "@aztec/foundation" "3.0.0-devnet.5"
-    "@aztec/key-store" "3.0.0-devnet.5"
-    "@aztec/kv-store" "3.0.0-devnet.5"
-    "@aztec/noir-protocol-circuits-types" "3.0.0-devnet.5"
-    "@aztec/noir-types" "3.0.0-devnet.5"
-    "@aztec/protocol-contracts" "3.0.0-devnet.5"
-    "@aztec/simulator" "3.0.0-devnet.5"
-    "@aztec/stdlib" "3.0.0-devnet.5"
+    "@aztec/bb-prover" "3.0.0-devnet.6-patch.1"
+    "@aztec/bb.js" "3.0.0-devnet.6-patch.1"
+    "@aztec/builder" "3.0.0-devnet.6-patch.1"
+    "@aztec/constants" "3.0.0-devnet.6-patch.1"
+    "@aztec/ethereum" "3.0.0-devnet.6-patch.1"
+    "@aztec/foundation" "3.0.0-devnet.6-patch.1"
+    "@aztec/key-store" "3.0.0-devnet.6-patch.1"
+    "@aztec/kv-store" "3.0.0-devnet.6-patch.1"
+    "@aztec/noir-protocol-circuits-types" "3.0.0-devnet.6-patch.1"
+    "@aztec/noir-types" "3.0.0-devnet.6-patch.1"
+    "@aztec/protocol-contracts" "3.0.0-devnet.6-patch.1"
+    "@aztec/simulator" "3.0.0-devnet.6-patch.1"
+    "@aztec/stdlib" "3.0.0-devnet.6-patch.1"
     koa "^2.16.1"
     koa-router "^13.1.1"
     lodash.omit "^4.5.0"
     sha3 "^2.1.4"
     tslib "^2.4.0"
-    viem "npm:@spalladino/viem@2.38.2-eip7594.0"
+    viem "npm:@aztec/viem@2.38.2"
 
-"@aztec/simulator@3.0.0-devnet.5":
-  version "3.0.0-devnet.5"
-  resolved "https://registry.yarnpkg.com/@aztec/simulator/-/simulator-3.0.0-devnet.5.tgz#e2227b086c1345f53df54c38b1ae1987a38226f5"
-  integrity sha512-XMSeJNbTfzqtaF32aiikHKkShn7NbBwAHpdi1qJvfpeMcGk2PvFE/1cyiwY89iQHdfRG24f3mS4cl7ekRcFymg==
+"@aztec/simulator@3.0.0-devnet.6-patch.1":
+  version "3.0.0-devnet.6-patch.1"
+  resolved "https://registry.yarnpkg.com/@aztec/simulator/-/simulator-3.0.0-devnet.6-patch.1.tgz#0c22af0f6be531c8b32b0f735a3e8ae207530cb7"
+  integrity sha512-nDXLLCYMDVTCi8uUUBGO715f4Q+KyoKPa8p0bpJ/08y99aPT67BoouUJE0XXAv44MbQcLgt1SO0dwdW9Cc81Tg==
   dependencies:
-    "@aztec/constants" "3.0.0-devnet.5"
-    "@aztec/foundation" "3.0.0-devnet.5"
-    "@aztec/native" "3.0.0-devnet.5"
-    "@aztec/noir-acvm_js" "3.0.0-devnet.5"
-    "@aztec/noir-noirc_abi" "3.0.0-devnet.5"
-    "@aztec/noir-protocol-circuits-types" "3.0.0-devnet.5"
-    "@aztec/noir-types" "3.0.0-devnet.5"
-    "@aztec/protocol-contracts" "3.0.0-devnet.5"
-    "@aztec/stdlib" "3.0.0-devnet.5"
-    "@aztec/telemetry-client" "3.0.0-devnet.5"
-    "@aztec/world-state" "3.0.0-devnet.5"
+    "@aztec/constants" "3.0.0-devnet.6-patch.1"
+    "@aztec/foundation" "3.0.0-devnet.6-patch.1"
+    "@aztec/native" "3.0.0-devnet.6-patch.1"
+    "@aztec/noir-acvm_js" "3.0.0-devnet.6-patch.1"
+    "@aztec/noir-noirc_abi" "3.0.0-devnet.6-patch.1"
+    "@aztec/noir-protocol-circuits-types" "3.0.0-devnet.6-patch.1"
+    "@aztec/noir-types" "3.0.0-devnet.6-patch.1"
+    "@aztec/protocol-contracts" "3.0.0-devnet.6-patch.1"
+    "@aztec/stdlib" "3.0.0-devnet.6-patch.1"
+    "@aztec/telemetry-client" "3.0.0-devnet.6-patch.1"
+    "@aztec/world-state" "3.0.0-devnet.6-patch.1"
     lodash.clonedeep "^4.5.0"
     lodash.merge "^4.6.2"
     tslib "^2.4.0"
 
-"@aztec/stdlib@3.0.0-devnet.5":
-  version "3.0.0-devnet.5"
-  resolved "https://registry.yarnpkg.com/@aztec/stdlib/-/stdlib-3.0.0-devnet.5.tgz#27107193bd38d2533626a6f33a9466896c490def"
-  integrity sha512-1AtQUnRSPuFG0hziJ/GFLAiumTBS7msgwMRHxGPg9NHtuNNrVFCw1ya2JwBuaIZPktuNBToRm7YjiOyCO5+04g==
+"@aztec/stdlib@3.0.0-devnet.6-patch.1":
+  version "3.0.0-devnet.6-patch.1"
+  resolved "https://registry.yarnpkg.com/@aztec/stdlib/-/stdlib-3.0.0-devnet.6-patch.1.tgz#0f82be8011843165519293f11e9ec9c43bc86a5f"
+  integrity sha512-nljgFQ046BKWg10HTiYD/UjrC8rWs+8nRFWMVeAPrLiX0mWrjjMHkqag480U2ROO4YpdqqgbVujnNmQa/cLzuA==
   dependencies:
     "@aws-sdk/client-s3" "^3.892.0"
-    "@aztec/bb.js" "3.0.0-devnet.5"
-    "@aztec/blob-lib" "3.0.0-devnet.5"
-    "@aztec/constants" "3.0.0-devnet.5"
-    "@aztec/ethereum" "3.0.0-devnet.5"
-    "@aztec/foundation" "3.0.0-devnet.5"
-    "@aztec/l1-artifacts" "3.0.0-devnet.5"
-    "@aztec/noir-noirc_abi" "3.0.0-devnet.5"
+    "@aztec/bb.js" "3.0.0-devnet.6-patch.1"
+    "@aztec/blob-lib" "3.0.0-devnet.6-patch.1"
+    "@aztec/constants" "3.0.0-devnet.6-patch.1"
+    "@aztec/ethereum" "3.0.0-devnet.6-patch.1"
+    "@aztec/foundation" "3.0.0-devnet.6-patch.1"
+    "@aztec/l1-artifacts" "3.0.0-devnet.6-patch.1"
+    "@aztec/noir-noirc_abi" "3.0.0-devnet.6-patch.1"
     "@google-cloud/storage" "^7.15.0"
     axios "^1.12.0"
     json-stringify-deterministic "1.0.12"
@@ -912,16 +917,16 @@
     msgpackr "^1.11.2"
     pako "^2.1.0"
     tslib "^2.4.0"
-    viem "npm:@spalladino/viem@2.38.2-eip7594.0"
+    viem "npm:@aztec/viem@2.38.2"
     zod "^3.23.8"
 
-"@aztec/telemetry-client@3.0.0-devnet.5":
-  version "3.0.0-devnet.5"
-  resolved "https://registry.yarnpkg.com/@aztec/telemetry-client/-/telemetry-client-3.0.0-devnet.5.tgz#e4a084e4696b856ede4c32cd4653f81bf63bd6b2"
-  integrity sha512-66+x1ACeVyRTKHnlmYu9/CubvRQ8hO19Y5tJshP9hwkmsjXbY7LilaSatLNZKCEGHyeqRnrOx2aURYwesNwk9Q==
+"@aztec/telemetry-client@3.0.0-devnet.6-patch.1":
+  version "3.0.0-devnet.6-patch.1"
+  resolved "https://registry.yarnpkg.com/@aztec/telemetry-client/-/telemetry-client-3.0.0-devnet.6-patch.1.tgz#599032472c50ffe1d45641e9568ff1cae99c46b0"
+  integrity sha512-XZeLKSf2ws+2VEzGDESBkFo8kI9BGNTRXHpAJZ7NIFCbEGBwb44N0Rf8S8BBJgixARg7iUaiiFs2y2mBf3b2Gg==
   dependencies:
-    "@aztec/foundation" "3.0.0-devnet.5"
-    "@aztec/stdlib" "3.0.0-devnet.5"
+    "@aztec/foundation" "3.0.0-devnet.6-patch.1"
+    "@aztec/stdlib" "3.0.0-devnet.6-patch.1"
     "@opentelemetry/api" "^1.9.0"
     "@opentelemetry/api-logs" "^0.55.0"
     "@opentelemetry/core" "^1.28.0"
@@ -937,34 +942,47 @@
     "@opentelemetry/sdk-trace-node" "^1.28.0"
     "@opentelemetry/semantic-conventions" "^1.28.0"
     prom-client "^15.1.3"
-    viem "npm:@spalladino/viem@2.38.2-eip7594.0"
+    viem "npm:@aztec/viem@2.38.2"
 
-"@aztec/test-wallet@3.0.0-devnet.5":
-  version "3.0.0-devnet.5"
-  resolved "https://registry.yarnpkg.com/@aztec/test-wallet/-/test-wallet-3.0.0-devnet.5.tgz#aec81864e7e702583a744a7e706ae58d3df7b12f"
-  integrity sha512-A3j5AdhUSIFfTW4hc5ysob3NYgS+krsKKHMJrD8AvhXsMJMKSdY5nzshM584epbgrEmA3lVEw8h+vMRLs2UTVg==
+"@aztec/test-wallet@3.0.0-devnet.6-patch.1":
+  version "3.0.0-devnet.6-patch.1"
+  resolved "https://registry.yarnpkg.com/@aztec/test-wallet/-/test-wallet-3.0.0-devnet.6-patch.1.tgz#fc70b9c639ed77d1a04d449f2aaf36f5bfeee784"
+  integrity sha512-K9jZrWN2XKzLm9X3prLwuvNPFKf9q+jc6jnuesHAMDsLDMDjG5YYBlLfYYHsNI6DbpHT0CxGDgPFuK4qYB3Dqg==
   dependencies:
-    "@aztec/accounts" "3.0.0-devnet.5"
-    "@aztec/aztec.js" "3.0.0-devnet.5"
-    "@aztec/entrypoints" "3.0.0-devnet.5"
-    "@aztec/foundation" "3.0.0-devnet.5"
-    "@aztec/noir-contracts.js" "3.0.0-devnet.5"
-    "@aztec/pxe" "3.0.0-devnet.5"
-    "@aztec/stdlib" "3.0.0-devnet.5"
+    "@aztec/accounts" "3.0.0-devnet.6-patch.1"
+    "@aztec/aztec.js" "3.0.0-devnet.6-patch.1"
+    "@aztec/entrypoints" "3.0.0-devnet.6-patch.1"
+    "@aztec/foundation" "3.0.0-devnet.6-patch.1"
+    "@aztec/noir-contracts.js" "3.0.0-devnet.6-patch.1"
+    "@aztec/pxe" "3.0.0-devnet.6-patch.1"
+    "@aztec/stdlib" "3.0.0-devnet.6-patch.1"
+    "@aztec/wallet-sdk" "3.0.0-devnet.6-patch.1"
 
-"@aztec/world-state@3.0.0-devnet.5":
-  version "3.0.0-devnet.5"
-  resolved "https://registry.yarnpkg.com/@aztec/world-state/-/world-state-3.0.0-devnet.5.tgz#a069815710c00c0047fd42d233f91ce5357b81fc"
-  integrity sha512-R420F5CDswUN+m9HloaIGiuuQDJoDEy2nuBElBXA6Dno6+kbTeOGP7vXxOnLS/E9gCIk5Yn5iBB4OAb6WMryZQ==
+"@aztec/wallet-sdk@3.0.0-devnet.6-patch.1":
+  version "3.0.0-devnet.6-patch.1"
+  resolved "https://registry.yarnpkg.com/@aztec/wallet-sdk/-/wallet-sdk-3.0.0-devnet.6-patch.1.tgz#1ec5ac27f6d5b29758606457712c7966325b74a0"
+  integrity sha512-acshskh0gWYwanEDpc2lfwAuoexsf0halQsJRCFjMgkRW1nryEUefBGsRe0Ztq572OVNCpd8KpJRzDl4OcVjPg==
   dependencies:
-    "@aztec/constants" "3.0.0-devnet.5"
-    "@aztec/foundation" "3.0.0-devnet.5"
-    "@aztec/kv-store" "3.0.0-devnet.5"
-    "@aztec/merkle-tree" "3.0.0-devnet.5"
-    "@aztec/native" "3.0.0-devnet.5"
-    "@aztec/protocol-contracts" "3.0.0-devnet.5"
-    "@aztec/stdlib" "3.0.0-devnet.5"
-    "@aztec/telemetry-client" "3.0.0-devnet.5"
+    "@aztec/aztec.js" "3.0.0-devnet.6-patch.1"
+    "@aztec/constants" "3.0.0-devnet.6-patch.1"
+    "@aztec/entrypoints" "3.0.0-devnet.6-patch.1"
+    "@aztec/foundation" "3.0.0-devnet.6-patch.1"
+    "@aztec/pxe" "3.0.0-devnet.6-patch.1"
+    "@aztec/stdlib" "3.0.0-devnet.6-patch.1"
+
+"@aztec/world-state@3.0.0-devnet.6-patch.1":
+  version "3.0.0-devnet.6-patch.1"
+  resolved "https://registry.yarnpkg.com/@aztec/world-state/-/world-state-3.0.0-devnet.6-patch.1.tgz#78b8cc83a67ca612d55e431219f2ac497ac4803e"
+  integrity sha512-6/svpdxdb/XkBGu+YH+EJZpnyCTyg4oZ31Mm1RsnYRUYz6gyZjh6w0CuiIPP3FOhnzfnvBCNrzcVK3apv7FImg==
+  dependencies:
+    "@aztec/constants" "3.0.0-devnet.6-patch.1"
+    "@aztec/foundation" "3.0.0-devnet.6-patch.1"
+    "@aztec/kv-store" "3.0.0-devnet.6-patch.1"
+    "@aztec/merkle-tree" "3.0.0-devnet.6-patch.1"
+    "@aztec/native" "3.0.0-devnet.6-patch.1"
+    "@aztec/protocol-contracts" "3.0.0-devnet.6-patch.1"
+    "@aztec/stdlib" "3.0.0-devnet.6-patch.1"
+    "@aztec/telemetry-client" "3.0.0-devnet.6-patch.1"
     tslib "^2.4.0"
     zod "^3.23.8"
 
@@ -1861,10 +1879,15 @@
   resolved "https://registry.yarnpkg.com/@noble/hashes/-/hashes-1.6.0.tgz#d4bfb516ad6e7b5111c216a5cc7075f4cf19e6c5"
   integrity sha512-YUULf0Uk4/mAA89w+k3+yUYh6NrEvxZa5T6SY3wlMvE2chHkxFUUIDI8/XW1QSC357iA5pSnqt7XEhvFOqmDyQ==
 
-"@noble/hashes@1.8.0", "@noble/hashes@^1.8.0", "@noble/hashes@~1.8.0":
+"@noble/hashes@1.8.0", "@noble/hashes@^1.6.1", "@noble/hashes@^1.8.0", "@noble/hashes@~1.8.0":
   version "1.8.0"
   resolved "https://registry.yarnpkg.com/@noble/hashes/-/hashes-1.8.0.tgz#cee43d801fcef9644b11b8194857695acd5f815a"
   integrity sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==
+
+"@noble/hashes@2.0.1":
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/@noble/hashes/-/hashes-2.0.1.tgz#fc1a928061d1232b0a52bb754393c37a5216c89e"
+  integrity sha512-XlOlEbQcE9fmuXxrVTXCTlG2nlRXa9Rj3rr5Ue/+tX+nmkgbX720YHh0VR3hBF9xDvwnb8D2shVGOwNx+ulArw==
 
 "@opentelemetry/api-logs@0.55.0", "@opentelemetry/api-logs@^0.55.0":
   version "0.55.0"
@@ -2126,6 +2149,11 @@
   resolved "https://registry.yarnpkg.com/@protobufjs/utf8/-/utf8-1.1.0.tgz#a777360b5b39a1a2e5106f8e858f2fd2d060c570"
   integrity sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw==
 
+"@scure/base@2.0.0":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@scure/base/-/base-2.0.0.tgz#ba6371fddf92c2727e88ad6ab485db6e624f9a98"
+  integrity sha512-3E1kpuZginKkek01ovG8krQ0Z44E3DHPjc5S2rjJw9lZn3KSQOs8S7wqikF/AH7iRanHypj85uGyxk0XAyC37w==
+
 "@scure/base@~1.2.5":
   version "1.2.6"
   resolved "https://registry.yarnpkg.com/@scure/base/-/base-1.2.6.tgz#ca917184b8231394dd8847509c67a0be522e59f6"
@@ -2147,6 +2175,14 @@
   dependencies:
     "@noble/hashes" "~1.8.0"
     "@scure/base" "~1.2.5"
+
+"@scure/bip39@^2.0.1":
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/@scure/bip39/-/bip39-2.0.1.tgz#47a6dc15e04faf200041239d46ae3bb7c3c96add"
+  integrity sha512-PsxdFj/d2AcJcZDX1FXN3dDgitDDTmwf78rKZq1a6c1P1Nan1X/Sxc7667zU3U+AN60g7SxxP0YCVw2H/hBycg==
+  dependencies:
+    "@noble/hashes" "2.0.1"
+    "@scure/base" "2.0.0"
 
 "@sinclair/typebox@^0.27.8":
   version "0.27.8"
@@ -6088,10 +6124,10 @@ vary@^1.1.2:
   resolved "https://registry.yarnpkg.com/vary/-/vary-1.1.2.tgz#2299f02c6ded30d4a5961b0b9f74524a18f634fc"
   integrity sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==
 
-"viem@npm:@spalladino/viem@2.38.2-eip7594.0":
-  version "2.38.2-eip7594.0"
-  resolved "https://registry.yarnpkg.com/@spalladino/viem/-/viem-2.38.2-eip7594.0.tgz#d875366821c5fb07b8ed6f52610c21e0e3a761cd"
-  integrity sha512-1gwcB0wxqUoSuzbwTafhqLOeNPWOaIKkSUUvzgsg5gBDOXDxA8tPJWUXBFFdr640maizWRjTbP9GLuLzgMeSuQ==
+"viem@npm:@aztec/viem@2.38.2":
+  version "2.38.2"
+  resolved "https://registry.yarnpkg.com/@aztec/viem/-/viem-2.38.2.tgz#9c626b46569cce1f30f08f7be23fb73846aea520"
+  integrity sha512-q975q5/On5DSTQDJb0yu0AewnCPIckP4EHp2XOx1GrRn0yJd3TdOKVwuH7HjWtyvh3moFaPogBSHnp7bj4GpdQ==
   dependencies:
     "@noble/curves" "1.9.1"
     "@noble/hashes" "1.8.0"

--- a/recursive_verification/contract/Nargo.toml
+++ b/recursive_verification/contract/Nargo.toml
@@ -4,5 +4,5 @@ type = "contract"
 authors = ["Satyam Bansal"]
 
 [dependencies]
-aztec = { git = "https://github.com/AztecProtocol/aztec-packages/", tag = "v3.0.0-devnet.6-patch.1", directory = "noir-projects/aztec-nr/aztec" }
+aztec = { git = "https://github.com/AztecProtocol/aztec-nr/", tag = "v3.0.0-devnet.6-patch.1", directory = "aztec" }
 bb_proof_verification = { git = "https://github.com/AztecProtocol/aztec-packages/", tag = "v3.0.0-devnet.6-patch.1", directory = "barretenberg/noir/bb_proof_verification" }

--- a/test-wallet-webapp/README.md
+++ b/test-wallet-webapp/README.md
@@ -4,12 +4,12 @@ This tutorial demonstrates how to build a browser-based wallet application for A
 
 ## Aztec Version Compatibility
 
-This example is compatible with **Aztec v3.0.0-devnet.20251212**.
+This example is compatible with **Aztec v3.0.0-devnet.6-patch.1**.
 
 To set this version:
 
 ```bash
-aztec-up 3.0.0-devnet.20251212
+aztec-up 3.0.0-devnet.6-patch.1
 ```
 
 ## What You'll Build
@@ -67,10 +67,10 @@ yarn install
 ### 2. Install Aztec Dependencies
 
 ```bash
-yarn add @aztec/accounts@3.0.0-devnet.20251212 \
-         @aztec/aztec.js@3.0.0-devnet.20251212 \
-         @aztec/test-wallet@3.0.0-devnet.20251212 \
-         @aztec/noir-contracts.js@3.0.0-devnet.20251212
+yarn add @aztec/accounts@3.0.0-devnet.6-patch.1 \
+         @aztec/aztec.js@3.0.0-devnet.6-patch.1 \
+         @aztec/test-wallet@3.0.0-devnet.6-patch.1 \
+         @aztec/noir-contracts.js@3.0.0-devnet.6-patch.1
 ```
 
 ### 3. Install Build Tooling Dependencies
@@ -260,7 +260,7 @@ Check browser console - these headers must be present in the response.
 **Problem**: Cannot resolve Aztec packages or their dependencies.
 
 **Solution**:
-- Ensure all Aztec packages are on the **same version** (e.g., `3.0.0-devnet.20251212`)
+- Ensure all Aztec packages are on the **same version** (e.g., `3.0.0-devnet.6-patch.1`)
 - Verify WASM modules are excluded in `optimizeDeps.exclude`
 - Clear Vite cache: `rm -rf node_modules/.vite`
 

--- a/test-wallet-webapp/package.json
+++ b/test-wallet-webapp/package.json
@@ -10,11 +10,11 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@aztec/accounts": "3.0.0-devnet.20251212",
-    "@aztec/aztec.js": "3.0.0-devnet.20251212",
-    "@aztec/test-wallet": "3.0.0-devnet.20251212",
-    "@aztec/noir-contracts.js": "3.0.0-devnet.20251212",
-    "@aztec/pxe": "3.0.0-devnet.20251212",
+    "@aztec/accounts": "3.0.0-devnet.6-patch.1",
+    "@aztec/aztec.js": "3.0.0-devnet.6-patch.1",
+    "@aztec/test-wallet": "3.0.0-devnet.6-patch.1",
+    "@aztec/noir-contracts.js": "3.0.0-devnet.6-patch.1",
+    "@aztec/pxe": "3.0.0-devnet.6-patch.1",
     "react": "^19.2.0",
     "react-dom": "^19.2.0"
   },

--- a/test-wallet-webapp/src/App.tsx
+++ b/test-wallet-webapp/src/App.tsx
@@ -112,7 +112,7 @@ function App() {
 
     try {
       const contract = await PrivateVotingContract.at(contractAddress, wallet);
-      await contract.methods.cast_vote(1n).send({
+      await contract.methods.cast_vote({ id: 1n }, 1n).send({
         from: address
       }).wait();
 

--- a/test-wallet-webapp/yarn.lock
+++ b/test-wallet-webapp/yarn.lock
@@ -588,59 +588,59 @@
   resolved "https://registry.yarnpkg.com/@aws/lambda-invoke-store/-/lambda-invoke-store-0.2.1.tgz#ceecff9ebe1f6199369e6911f38633fac3322811"
   integrity sha512-sIyFcoPZkTtNu9xFeEoynMef3bPJIAbOfUh+ueYcfhVl6xm2VRtMcMclSxmZCMnHHd4hlYKJeq/aggmBEWynww==
 
-"@aztec/accounts@3.0.0-devnet.20251212":
-  version "3.0.0-devnet.20251212"
-  resolved "https://registry.yarnpkg.com/@aztec/accounts/-/accounts-3.0.0-devnet.20251212.tgz#9bbc3097a7e0579e922a87880eaea760ac0e718c"
-  integrity sha512-nmXLe6N45F/V6SZWgLEvU2h58vC23eYUtuHROnaLBzh579DUv2TTSxSF8BU/1hKPKCYaloLWXy7z7F6WVMZaVg==
+"@aztec/accounts@3.0.0-devnet.6-patch.1":
+  version "3.0.0-devnet.6-patch.1"
+  resolved "https://registry.yarnpkg.com/@aztec/accounts/-/accounts-3.0.0-devnet.6-patch.1.tgz#05b44647c732e3deb723571e73c10a36d762c154"
+  integrity sha512-0iJN0t6AYgv6rxYjLSQvbwo5n8zEfJdwHoydIkqSbSLbymU5NoDnNB7jwl1omAmWqBAKN4hOr4p8Gh2ZldYIsQ==
   dependencies:
-    "@aztec/aztec.js" "3.0.0-devnet.20251212"
-    "@aztec/entrypoints" "3.0.0-devnet.20251212"
-    "@aztec/ethereum" "3.0.0-devnet.20251212"
-    "@aztec/foundation" "3.0.0-devnet.20251212"
-    "@aztec/stdlib" "3.0.0-devnet.20251212"
+    "@aztec/aztec.js" "3.0.0-devnet.6-patch.1"
+    "@aztec/entrypoints" "3.0.0-devnet.6-patch.1"
+    "@aztec/ethereum" "3.0.0-devnet.6-patch.1"
+    "@aztec/foundation" "3.0.0-devnet.6-patch.1"
+    "@aztec/stdlib" "3.0.0-devnet.6-patch.1"
     tslib "^2.4.0"
 
-"@aztec/aztec.js@3.0.0-devnet.20251212":
-  version "3.0.0-devnet.20251212"
-  resolved "https://registry.yarnpkg.com/@aztec/aztec.js/-/aztec.js-3.0.0-devnet.20251212.tgz#8c84a5a60bf092360f6f80c6575b38c3dc41aa74"
-  integrity sha512-k0o3fZlDEf8XaBDFIhKIOgQES09/xOiCNnaaCBwfQgifPtxHKsdTnomXHVVwgJWD/gS7TtwLnNfvjYmEKy50cA==
+"@aztec/aztec.js@3.0.0-devnet.6-patch.1":
+  version "3.0.0-devnet.6-patch.1"
+  resolved "https://registry.yarnpkg.com/@aztec/aztec.js/-/aztec.js-3.0.0-devnet.6-patch.1.tgz#cbf2c015c76a7e346044cf6a0b7724f1a85d661f"
+  integrity sha512-vPba9qQg1IUyg9aTyzEJfHwtwb7guCF2BiBAwnqPKkhoSG06CoDHQfU7T+JqxY9QpdWqDGUSfvDCr5wRFlEL0g==
   dependencies:
-    "@aztec/constants" "3.0.0-devnet.20251212"
-    "@aztec/entrypoints" "3.0.0-devnet.20251212"
-    "@aztec/ethereum" "3.0.0-devnet.20251212"
-    "@aztec/foundation" "3.0.0-devnet.20251212"
-    "@aztec/l1-artifacts" "3.0.0-devnet.20251212"
-    "@aztec/protocol-contracts" "3.0.0-devnet.20251212"
-    "@aztec/stdlib" "3.0.0-devnet.20251212"
+    "@aztec/constants" "3.0.0-devnet.6-patch.1"
+    "@aztec/entrypoints" "3.0.0-devnet.6-patch.1"
+    "@aztec/ethereum" "3.0.0-devnet.6-patch.1"
+    "@aztec/foundation" "3.0.0-devnet.6-patch.1"
+    "@aztec/l1-artifacts" "3.0.0-devnet.6-patch.1"
+    "@aztec/protocol-contracts" "3.0.0-devnet.6-patch.1"
+    "@aztec/stdlib" "3.0.0-devnet.6-patch.1"
     axios "^1.12.0"
     tslib "^2.4.0"
     viem "npm:@aztec/viem@2.38.2"
     zod "^3.23.8"
 
-"@aztec/bb-prover@3.0.0-devnet.20251212":
-  version "3.0.0-devnet.20251212"
-  resolved "https://registry.yarnpkg.com/@aztec/bb-prover/-/bb-prover-3.0.0-devnet.20251212.tgz#86540c0272e910cbc35dffc97119dbf712521f94"
-  integrity sha512-wFb3yVIoZSCdcmcZTKBHsdzNtvt8S3nVhPFagoEL6ts8fJtrzYS1tYZ5mLukpwILkNJGnb+R+SLpaWEBnU7fTg==
+"@aztec/bb-prover@3.0.0-devnet.6-patch.1":
+  version "3.0.0-devnet.6-patch.1"
+  resolved "https://registry.yarnpkg.com/@aztec/bb-prover/-/bb-prover-3.0.0-devnet.6-patch.1.tgz#22155bbba2571eddf2cbc0cf0eccc3000224ce95"
+  integrity sha512-SMuVhCN6iA4WJOdk2Aj1iuK/+6I27cWCu0V/rm1ZQyNEryPteIXKnXleG5HWSZ+MRIngOAut+hT8cFhHRSfrLA==
   dependencies:
-    "@aztec/bb.js" "3.0.0-devnet.20251212"
-    "@aztec/constants" "3.0.0-devnet.20251212"
-    "@aztec/foundation" "3.0.0-devnet.20251212"
-    "@aztec/noir-noirc_abi" "3.0.0-devnet.20251212"
-    "@aztec/noir-protocol-circuits-types" "3.0.0-devnet.20251212"
-    "@aztec/noir-types" "3.0.0-devnet.20251212"
-    "@aztec/simulator" "3.0.0-devnet.20251212"
-    "@aztec/stdlib" "3.0.0-devnet.20251212"
-    "@aztec/telemetry-client" "3.0.0-devnet.20251212"
-    "@aztec/world-state" "3.0.0-devnet.20251212"
+    "@aztec/bb.js" "3.0.0-devnet.6-patch.1"
+    "@aztec/constants" "3.0.0-devnet.6-patch.1"
+    "@aztec/foundation" "3.0.0-devnet.6-patch.1"
+    "@aztec/noir-noirc_abi" "3.0.0-devnet.6-patch.1"
+    "@aztec/noir-protocol-circuits-types" "3.0.0-devnet.6-patch.1"
+    "@aztec/noir-types" "3.0.0-devnet.6-patch.1"
+    "@aztec/simulator" "3.0.0-devnet.6-patch.1"
+    "@aztec/stdlib" "3.0.0-devnet.6-patch.1"
+    "@aztec/telemetry-client" "3.0.0-devnet.6-patch.1"
+    "@aztec/world-state" "3.0.0-devnet.6-patch.1"
     commander "^12.1.0"
     pako "^2.1.0"
     source-map-support "^0.5.21"
     tslib "^2.4.0"
 
-"@aztec/bb.js@3.0.0-devnet.20251212":
-  version "3.0.0-devnet.20251212"
-  resolved "https://registry.yarnpkg.com/@aztec/bb.js/-/bb.js-3.0.0-devnet.20251212.tgz#cbf4c76db7b57f5515a0e1168b37200a9e91734b"
-  integrity sha512-9xqm3d9H9aDus8xGf7b7Bd9rkjYqp1PHHMmqNT8FJ/Rv5Pn/rJgwE+d4ZWJtm+inIIu8D8AeKTBc9bEEPjENUQ==
+"@aztec/bb.js@3.0.0-devnet.6-patch.1":
+  version "3.0.0-devnet.6-patch.1"
+  resolved "https://registry.yarnpkg.com/@aztec/bb.js/-/bb.js-3.0.0-devnet.6-patch.1.tgz#6781fa91d7faeb5a3bc1e3f8fabc4ddd4a9bb92c"
+  integrity sha512-ULRG/Ky5h2Lpaw4lXjkEzJdQVgfCFhBY9Fb0mL+Y+yC+thi2T5rQmmAwh5Qmr7F+KwKcozgtryV7Ook3rVjbhA==
   dependencies:
     comlink "^4.4.1"
     commander "^12.1.0"
@@ -649,54 +649,54 @@
     pako "^2.1.0"
     tslib "^2.4.0"
 
-"@aztec/blob-lib@3.0.0-devnet.20251212":
-  version "3.0.0-devnet.20251212"
-  resolved "https://registry.yarnpkg.com/@aztec/blob-lib/-/blob-lib-3.0.0-devnet.20251212.tgz#cc8f3e89b0078b761e46e6adbdf3e57e0480db4a"
-  integrity sha512-DiJBFkcPxuGBN51S6EaJfU+UxejcOwUzKFAIskPIHheb0kSFAad/4VVhhadtCudN72+iIBCExUtp7qBdJmePYQ==
+"@aztec/blob-lib@3.0.0-devnet.6-patch.1":
+  version "3.0.0-devnet.6-patch.1"
+  resolved "https://registry.yarnpkg.com/@aztec/blob-lib/-/blob-lib-3.0.0-devnet.6-patch.1.tgz#ca476037b413acbe75766785e5b26da09afe8c54"
+  integrity sha512-l3YxkxfAm3RF7016QHXFxlQF58wgSpI0u7xfe6NpupO7k3gnCOrLm8p6GcBGcIoTIcf5GJzK2QfZvBsX+WVZHw==
   dependencies:
-    "@aztec/constants" "3.0.0-devnet.20251212"
-    "@aztec/foundation" "3.0.0-devnet.20251212"
+    "@aztec/constants" "3.0.0-devnet.6-patch.1"
+    "@aztec/foundation" "3.0.0-devnet.6-patch.1"
     "@crate-crypto/node-eth-kzg" "^0.10.0"
     tslib "^2.4.0"
 
-"@aztec/builder@3.0.0-devnet.20251212":
-  version "3.0.0-devnet.20251212"
-  resolved "https://registry.yarnpkg.com/@aztec/builder/-/builder-3.0.0-devnet.20251212.tgz#1befe5bc1d0f10e87820fd775ad279589664360e"
-  integrity sha512-BUvWzdwUK7jnfpjsvdgbOpAvdZi3njH3MQHSIW3VYyEgUlVNT9NJtmCzY222vnBPeN4XLkNwBSaEe1DH+VuULw==
+"@aztec/builder@3.0.0-devnet.6-patch.1":
+  version "3.0.0-devnet.6-patch.1"
+  resolved "https://registry.yarnpkg.com/@aztec/builder/-/builder-3.0.0-devnet.6-patch.1.tgz#a25cd90e83e8c2595c6a3c0440c683e42e258af2"
+  integrity sha512-IPBXJVhDu3T3K59uVCBX/jK+/Wkn5Z0coBzlcRQkr6puLv8sZod8vPwPrEGeWxOYz6VZN7JUkJup5ZqKR2vFgg==
   dependencies:
-    "@aztec/foundation" "3.0.0-devnet.20251212"
-    "@aztec/stdlib" "3.0.0-devnet.20251212"
+    "@aztec/foundation" "3.0.0-devnet.6-patch.1"
+    "@aztec/stdlib" "3.0.0-devnet.6-patch.1"
     commander "^12.1.0"
 
-"@aztec/constants@3.0.0-devnet.20251212":
-  version "3.0.0-devnet.20251212"
-  resolved "https://registry.yarnpkg.com/@aztec/constants/-/constants-3.0.0-devnet.20251212.tgz#2960ebfea2852313c76af6b967c53958e03006cb"
-  integrity sha512-R0pYLhWUnDago/MO8+iuG/2yrP4yVDZuQvOmXwDqp5ed+SR4zj8sqvC52paXrOxhcLpheVpEHp2TuGKtmssvtg==
+"@aztec/constants@3.0.0-devnet.6-patch.1":
+  version "3.0.0-devnet.6-patch.1"
+  resolved "https://registry.yarnpkg.com/@aztec/constants/-/constants-3.0.0-devnet.6-patch.1.tgz#c0588e4039de977949b997cb65f45721539cf6bd"
+  integrity sha512-YKH/JQ+Qpd8X9xtWwTBc1yVChjfO9yKFPH2x/LIll89rkPT9GU3OKQeKpnXOKlnC/2IWW2ZExASfwttp8TWtXg==
   dependencies:
-    "@aztec/foundation" "3.0.0-devnet.20251212"
+    "@aztec/foundation" "3.0.0-devnet.6-patch.1"
     tslib "^2.4.0"
 
-"@aztec/entrypoints@3.0.0-devnet.20251212":
-  version "3.0.0-devnet.20251212"
-  resolved "https://registry.yarnpkg.com/@aztec/entrypoints/-/entrypoints-3.0.0-devnet.20251212.tgz#a67151a3d9c078b91bf8e3869cddd64c784eaab5"
-  integrity sha512-XlMkUqetlM1lzVycxmIdQ1FtM2kfFtKU+7GG01mGnhawFHJnBT8EqMQjxaSKCO9fQYTNIl1oUELhyzpiWL/ztg==
+"@aztec/entrypoints@3.0.0-devnet.6-patch.1":
+  version "3.0.0-devnet.6-patch.1"
+  resolved "https://registry.yarnpkg.com/@aztec/entrypoints/-/entrypoints-3.0.0-devnet.6-patch.1.tgz#ade9929ab6351c990844649b62a2ccc7ce474400"
+  integrity sha512-rHVRJGk7rxw16rxxQzfojnYjqK0zBtQVghLj1+4p91looN0T4xS8sEXr4jCGPG78uj3NLkYLuPQCQCDVmWXVcA==
   dependencies:
-    "@aztec/constants" "3.0.0-devnet.20251212"
-    "@aztec/foundation" "3.0.0-devnet.20251212"
-    "@aztec/protocol-contracts" "3.0.0-devnet.20251212"
-    "@aztec/stdlib" "3.0.0-devnet.20251212"
+    "@aztec/constants" "3.0.0-devnet.6-patch.1"
+    "@aztec/foundation" "3.0.0-devnet.6-patch.1"
+    "@aztec/protocol-contracts" "3.0.0-devnet.6-patch.1"
+    "@aztec/stdlib" "3.0.0-devnet.6-patch.1"
     tslib "^2.4.0"
     zod "^3.23.8"
 
-"@aztec/ethereum@3.0.0-devnet.20251212":
-  version "3.0.0-devnet.20251212"
-  resolved "https://registry.yarnpkg.com/@aztec/ethereum/-/ethereum-3.0.0-devnet.20251212.tgz#910f811f04c319edbde9d1af192b8753936061ba"
-  integrity sha512-smAL13K73bpP5SXDYoYukQsnOa6iHC7a1HP1tf3Llk9mF0hS1BXV+kyrltiVeVHSN5/UkZN4WZ50yQ5CCeq6rg==
+"@aztec/ethereum@3.0.0-devnet.6-patch.1":
+  version "3.0.0-devnet.6-patch.1"
+  resolved "https://registry.yarnpkg.com/@aztec/ethereum/-/ethereum-3.0.0-devnet.6-patch.1.tgz#16a1f80facf54441b4f606d01fa0a83103f6d74f"
+  integrity sha512-J1QxJFpYIcWw3Se8eVBWMTvZsGTngwz7h6wgWEkUj2noFe2zPpvASGe389rrHPqqdsQ70yZ92kDaHQ2KyhDzLw==
   dependencies:
-    "@aztec/blob-lib" "3.0.0-devnet.20251212"
-    "@aztec/constants" "3.0.0-devnet.20251212"
-    "@aztec/foundation" "3.0.0-devnet.20251212"
-    "@aztec/l1-artifacts" "3.0.0-devnet.20251212"
+    "@aztec/blob-lib" "3.0.0-devnet.6-patch.1"
+    "@aztec/constants" "3.0.0-devnet.6-patch.1"
+    "@aztec/foundation" "3.0.0-devnet.6-patch.1"
+    "@aztec/l1-artifacts" "3.0.0-devnet.6-patch.1"
     "@viem/anvil" "^0.0.10"
     dotenv "^16.0.3"
     lodash.chunk "^4.2.0"
@@ -705,12 +705,12 @@
     viem "npm:@aztec/viem@2.38.2"
     zod "^3.23.8"
 
-"@aztec/foundation@3.0.0-devnet.20251212":
-  version "3.0.0-devnet.20251212"
-  resolved "https://registry.yarnpkg.com/@aztec/foundation/-/foundation-3.0.0-devnet.20251212.tgz#2871a76946ee051b7a42cbf9c9defa08220ea054"
-  integrity sha512-1yBGAJCO4VjmaZTx5qbJ2vW8yjWlLae524L08zOSGoEqF2RIkCvbQyIOaH/ZWb5n866LP66XhUfoaohPmgK+EA==
+"@aztec/foundation@3.0.0-devnet.6-patch.1":
+  version "3.0.0-devnet.6-patch.1"
+  resolved "https://registry.yarnpkg.com/@aztec/foundation/-/foundation-3.0.0-devnet.6-patch.1.tgz#feacdef89029695ccec0fa7d419faf595d5ab27a"
+  integrity sha512-8oNaZPdU0vMRPxHZzwkOfEPsC9IRswP1WXCqxgdQHYSufYNxNrDZ7aVQpuI0sPkA3BsCXzPb/tQTgD+E2WoYEQ==
   dependencies:
-    "@aztec/bb.js" "3.0.0-devnet.20251212"
+    "@aztec/bb.js" "3.0.0-devnet.6-patch.1"
     "@koa/cors" "^5.0.0"
     "@noble/curves" "=1.7.0"
     "@noble/hashes" "^1.6.1"
@@ -733,140 +733,140 @@
     undici "^5.28.5"
     zod "^3.23.8"
 
-"@aztec/key-store@3.0.0-devnet.20251212":
-  version "3.0.0-devnet.20251212"
-  resolved "https://registry.yarnpkg.com/@aztec/key-store/-/key-store-3.0.0-devnet.20251212.tgz#0d0bf89969a8e8a5f1f0db86d1f1cd703478af19"
-  integrity sha512-FMh8hsXZNMMz+DHDdKgTyeNfdH0FHiwQygDdi3n2rRr0Io7Jc3HMPqB3w5dFt8qKxTelNmFqll5XRu5IZDuAvg==
+"@aztec/key-store@3.0.0-devnet.6-patch.1":
+  version "3.0.0-devnet.6-patch.1"
+  resolved "https://registry.yarnpkg.com/@aztec/key-store/-/key-store-3.0.0-devnet.6-patch.1.tgz#962c91aa606131a6e38ab2845049bd07d7e46781"
+  integrity sha512-LV3JhRG0RW5O4CK5dB4MEOQQHM+N6HwHeQrJG9tZr5P52GzwT7PlBPmopzuq/iKIh48MNizfMTux5681UqBe2Q==
   dependencies:
-    "@aztec/constants" "3.0.0-devnet.20251212"
-    "@aztec/foundation" "3.0.0-devnet.20251212"
-    "@aztec/kv-store" "3.0.0-devnet.20251212"
-    "@aztec/stdlib" "3.0.0-devnet.20251212"
+    "@aztec/constants" "3.0.0-devnet.6-patch.1"
+    "@aztec/foundation" "3.0.0-devnet.6-patch.1"
+    "@aztec/kv-store" "3.0.0-devnet.6-patch.1"
+    "@aztec/stdlib" "3.0.0-devnet.6-patch.1"
     tslib "^2.4.0"
 
-"@aztec/kv-store@3.0.0-devnet.20251212":
-  version "3.0.0-devnet.20251212"
-  resolved "https://registry.yarnpkg.com/@aztec/kv-store/-/kv-store-3.0.0-devnet.20251212.tgz#6199beb780558a180200f9cc1b246fd7df009af1"
-  integrity sha512-Qe1aYRpQFHFwsvtNKLHphKNYxEB4vIOSqqgFME8oYw3nsq2AlV/Byrmw0x3jXVc15QLc6x8uTn1rXqpZK+u3tA==
+"@aztec/kv-store@3.0.0-devnet.6-patch.1":
+  version "3.0.0-devnet.6-patch.1"
+  resolved "https://registry.yarnpkg.com/@aztec/kv-store/-/kv-store-3.0.0-devnet.6-patch.1.tgz#19850f5423a7d45d59656a50e57bad478599fe2c"
+  integrity sha512-Y3hMLidonMlN3eC/Blc+o6dN9VY+byLJsPXvNu+snGc6QR8rPw2x+vM/+QInsx9AFoIRfDjZU+64QMLKS4bizw==
   dependencies:
-    "@aztec/constants" "3.0.0-devnet.20251212"
-    "@aztec/ethereum" "3.0.0-devnet.20251212"
-    "@aztec/foundation" "3.0.0-devnet.20251212"
-    "@aztec/native" "3.0.0-devnet.20251212"
-    "@aztec/stdlib" "3.0.0-devnet.20251212"
+    "@aztec/constants" "3.0.0-devnet.6-patch.1"
+    "@aztec/ethereum" "3.0.0-devnet.6-patch.1"
+    "@aztec/foundation" "3.0.0-devnet.6-patch.1"
+    "@aztec/native" "3.0.0-devnet.6-patch.1"
+    "@aztec/stdlib" "3.0.0-devnet.6-patch.1"
     idb "^8.0.0"
     lmdb "^3.2.0"
     msgpackr "^1.11.2"
     ohash "^2.0.11"
     ordered-binary "^1.5.3"
 
-"@aztec/l1-artifacts@3.0.0-devnet.20251212":
-  version "3.0.0-devnet.20251212"
-  resolved "https://registry.yarnpkg.com/@aztec/l1-artifacts/-/l1-artifacts-3.0.0-devnet.20251212.tgz#431713cd66794eb8d890f0f379a55809a7822e61"
-  integrity sha512-IGWQ8ie2W1Ok8bLnfmuvazULT9dPj9ozYDujcgI+lWYnUbTDR5ja7tfx9qG//9Um+FFKZL5JErm0qtsPSrO2tg==
+"@aztec/l1-artifacts@3.0.0-devnet.6-patch.1":
+  version "3.0.0-devnet.6-patch.1"
+  resolved "https://registry.yarnpkg.com/@aztec/l1-artifacts/-/l1-artifacts-3.0.0-devnet.6-patch.1.tgz#fb017bcf65cfa9a9610b64ad0dcc7ff4fd46b0b2"
+  integrity sha512-aO01TaullALg6Mn/GK/HgB9AB+8mxyrQi7X9It/i2u+SA8UiIQuwoBzr3uAA1hsWnRCSD+M7RikMBvVmVDlYkg==
   dependencies:
     tslib "^2.4.0"
 
-"@aztec/merkle-tree@3.0.0-devnet.20251212":
-  version "3.0.0-devnet.20251212"
-  resolved "https://registry.yarnpkg.com/@aztec/merkle-tree/-/merkle-tree-3.0.0-devnet.20251212.tgz#f9ecfd673d0639f9629906e5610fbe5e06dff824"
-  integrity sha512-uXJm69QJElxnnPah7JSynsw7+xaVzIOWFxqYLP9QgQG7M1MyYE9WQyK78LMRUb8iG3sW84udFcvdSuCMwL1YEw==
+"@aztec/merkle-tree@3.0.0-devnet.6-patch.1":
+  version "3.0.0-devnet.6-patch.1"
+  resolved "https://registry.yarnpkg.com/@aztec/merkle-tree/-/merkle-tree-3.0.0-devnet.6-patch.1.tgz#df973c1eea7ff561fc6b6545575df7813d32f10e"
+  integrity sha512-u6jt+4ATePLnCzACe1VGNYEjbRKDj19xgLtVa+nzcBBO527UIueKxQxjPZ8j9yMcLPGrSvDTdBqaOdm7uWPI4Q==
   dependencies:
-    "@aztec/foundation" "3.0.0-devnet.20251212"
-    "@aztec/kv-store" "3.0.0-devnet.20251212"
-    "@aztec/stdlib" "3.0.0-devnet.20251212"
+    "@aztec/foundation" "3.0.0-devnet.6-patch.1"
+    "@aztec/kv-store" "3.0.0-devnet.6-patch.1"
+    "@aztec/stdlib" "3.0.0-devnet.6-patch.1"
     sha256 "^0.2.0"
     tslib "^2.4.0"
 
-"@aztec/native@3.0.0-devnet.20251212":
-  version "3.0.0-devnet.20251212"
-  resolved "https://registry.yarnpkg.com/@aztec/native/-/native-3.0.0-devnet.20251212.tgz#eaaecdbacee3295077219de400b8eafa4c8c5e8a"
-  integrity sha512-UIUjQRK2S54Pr0tZinUek7rjtfh0fZbdxJFzEFTBElO/g5rExK8FUX8S1Fz3DfFOJNgBj9Y8RW2oj3yZEKxTvw==
+"@aztec/native@3.0.0-devnet.6-patch.1":
+  version "3.0.0-devnet.6-patch.1"
+  resolved "https://registry.yarnpkg.com/@aztec/native/-/native-3.0.0-devnet.6-patch.1.tgz#601c5bac626ea5fd60d45820205ec4b54c67f9c8"
+  integrity sha512-UNTdTD/sKJFzCjFjUcpX3g1ElxyIIDkkaMJek6CCb1rsXVtALgIx6K7QhRq26hkUPgS0pBpFPgznFOvh1bsE8w==
   dependencies:
-    "@aztec/bb.js" "3.0.0-devnet.20251212"
-    "@aztec/foundation" "3.0.0-devnet.20251212"
+    "@aztec/bb.js" "3.0.0-devnet.6-patch.1"
+    "@aztec/foundation" "3.0.0-devnet.6-patch.1"
     msgpackr "^1.11.2"
 
-"@aztec/noir-acvm_js@3.0.0-devnet.20251212":
-  version "3.0.0-devnet.20251212"
-  resolved "https://registry.yarnpkg.com/@aztec/noir-acvm_js/-/noir-acvm_js-3.0.0-devnet.20251212.tgz#efe93e644afed661fe6d5b17f4fd5cc273fa4e21"
-  integrity sha512-vQujIYW0urROyi/+REygX1YyHuHSBMSFyOc2P7pyFEILmlMH8ZLyLjtUWHm8bUa8gq8G+zsd7Bn2p+MEiBhMtg==
+"@aztec/noir-acvm_js@3.0.0-devnet.6-patch.1":
+  version "3.0.0-devnet.6-patch.1"
+  resolved "https://registry.yarnpkg.com/@aztec/noir-acvm_js/-/noir-acvm_js-3.0.0-devnet.6-patch.1.tgz#c6930c121c2a186cb7a071d46ff59b1ddda97da0"
+  integrity sha512-gJTPvM2bDzj+sVH5gmWgBo0tNyaecWyXmYwZCP4Cz5DtwfN7bcT4JAmjLex0u85i6rpJ+ij9ayPB8msqhvLJSw==
 
-"@aztec/noir-contracts.js@3.0.0-devnet.20251212":
-  version "3.0.0-devnet.20251212"
-  resolved "https://registry.yarnpkg.com/@aztec/noir-contracts.js/-/noir-contracts.js-3.0.0-devnet.20251212.tgz#91602e1ab1b517a12ebb90c868c1bd22d706c34d"
-  integrity sha512-+Jl3za8TTK9VkiDitj6cMCdpmD0A3buvafoVNPmTUU8AvO1YMTrs6OPDvMEXKVpmwRZI6zOCPF+0H1u9zDW5BA==
+"@aztec/noir-contracts.js@3.0.0-devnet.6-patch.1":
+  version "3.0.0-devnet.6-patch.1"
+  resolved "https://registry.yarnpkg.com/@aztec/noir-contracts.js/-/noir-contracts.js-3.0.0-devnet.6-patch.1.tgz#b9fdfec34de536ae579e3481177a046c27bf3598"
+  integrity sha512-GP1VX+qm5bkSsGpeekCWaLOAoMPFqpckx/WIqAyxJLlSTS7QuvANEulGJI22IBhktu133CtXXfzjATHPEGbN4g==
   dependencies:
-    "@aztec/aztec.js" "3.0.0-devnet.20251212"
+    "@aztec/aztec.js" "3.0.0-devnet.6-patch.1"
     tslib "^2.4.0"
 
-"@aztec/noir-noir_codegen@3.0.0-devnet.20251212":
-  version "3.0.0-devnet.20251212"
-  resolved "https://registry.yarnpkg.com/@aztec/noir-noir_codegen/-/noir-noir_codegen-3.0.0-devnet.20251212.tgz#8a278ca2f2e3e5c524047b96166ebe987dba00d0"
-  integrity sha512-yl1+tmypfKODxsq6PxPsCjRJokI3S+rU6gNvO6XLQTRuFkDIDfp4qDoevD9VnZvjtkataS2z99AylsJdxFToEQ==
+"@aztec/noir-noir_codegen@3.0.0-devnet.6-patch.1":
+  version "3.0.0-devnet.6-patch.1"
+  resolved "https://registry.yarnpkg.com/@aztec/noir-noir_codegen/-/noir-noir_codegen-3.0.0-devnet.6-patch.1.tgz#d7d614cb2cb828766977298076d8c3c48da95e16"
+  integrity sha512-dTvCSdNhSavN5vQ4rBZjD5A2mTgwnRXlNM4wOfJgk1bZEeuapJpD1bc98nV5e4a8C/G0TRgQT7CaxbrHluDdpw==
   dependencies:
-    "@aztec/noir-types" "3.0.0-devnet.20251212"
+    "@aztec/noir-types" "3.0.0-devnet.6-patch.1"
     glob "^11.0.3"
     ts-command-line-args "^2.5.1"
 
-"@aztec/noir-noirc_abi@3.0.0-devnet.20251212":
-  version "3.0.0-devnet.20251212"
-  resolved "https://registry.yarnpkg.com/@aztec/noir-noirc_abi/-/noir-noirc_abi-3.0.0-devnet.20251212.tgz#368242d4b23f3627086e00588bb34573fba69b46"
-  integrity sha512-HuABbS7Cr4xXFQ3Fqq86hoDzbAnxe7iXJK6Oow6Ak8PqNu1kdvZpwLLMpDvTE/1sCio+lEbnNmxpp5ko2yckSQ==
+"@aztec/noir-noirc_abi@3.0.0-devnet.6-patch.1":
+  version "3.0.0-devnet.6-patch.1"
+  resolved "https://registry.yarnpkg.com/@aztec/noir-noirc_abi/-/noir-noirc_abi-3.0.0-devnet.6-patch.1.tgz#9cc1a1ebbce77f74a9c08d587c9363bd28c99b36"
+  integrity sha512-+J9StgFWBSi+zhGTmXXNbe3LV3lJ7FC4nmwQP6VENVLzoo1icT6S77N0xrfbcHCbdqmzw8FtKz0BR69VuXdChQ==
   dependencies:
-    "@aztec/noir-types" "3.0.0-devnet.20251212"
+    "@aztec/noir-types" "3.0.0-devnet.6-patch.1"
 
-"@aztec/noir-protocol-circuits-types@3.0.0-devnet.20251212":
-  version "3.0.0-devnet.20251212"
-  resolved "https://registry.yarnpkg.com/@aztec/noir-protocol-circuits-types/-/noir-protocol-circuits-types-3.0.0-devnet.20251212.tgz#174eadaaba675393983609a5a5683d0e69912075"
-  integrity sha512-gBz5UbR1QV5bmg/6y+an77GEJmM2ed1/UCtJwGmbRjhA6Bq+l8ghTphAFtO2eOs/OOp6vaEOBWBCEvTUpF/j0w==
+"@aztec/noir-protocol-circuits-types@3.0.0-devnet.6-patch.1":
+  version "3.0.0-devnet.6-patch.1"
+  resolved "https://registry.yarnpkg.com/@aztec/noir-protocol-circuits-types/-/noir-protocol-circuits-types-3.0.0-devnet.6-patch.1.tgz#1abd030097cb9540d4bee70d8d133a3c5a587945"
+  integrity sha512-/e8nlQjsZIE1OKE53zlH8EJUkw24/IEZ3Zsj4HNoSQvKz63Zu0yoNrTst02owUYqTprrDuFj5YL8qouTo3UsXA==
   dependencies:
-    "@aztec/blob-lib" "3.0.0-devnet.20251212"
-    "@aztec/constants" "3.0.0-devnet.20251212"
-    "@aztec/foundation" "3.0.0-devnet.20251212"
-    "@aztec/noir-acvm_js" "3.0.0-devnet.20251212"
-    "@aztec/noir-noir_codegen" "3.0.0-devnet.20251212"
-    "@aztec/noir-noirc_abi" "3.0.0-devnet.20251212"
-    "@aztec/noir-types" "3.0.0-devnet.20251212"
-    "@aztec/stdlib" "3.0.0-devnet.20251212"
+    "@aztec/blob-lib" "3.0.0-devnet.6-patch.1"
+    "@aztec/constants" "3.0.0-devnet.6-patch.1"
+    "@aztec/foundation" "3.0.0-devnet.6-patch.1"
+    "@aztec/noir-acvm_js" "3.0.0-devnet.6-patch.1"
+    "@aztec/noir-noir_codegen" "3.0.0-devnet.6-patch.1"
+    "@aztec/noir-noirc_abi" "3.0.0-devnet.6-patch.1"
+    "@aztec/noir-types" "3.0.0-devnet.6-patch.1"
+    "@aztec/stdlib" "3.0.0-devnet.6-patch.1"
     change-case "^5.4.4"
     tslib "^2.4.0"
 
-"@aztec/noir-types@3.0.0-devnet.20251212":
-  version "3.0.0-devnet.20251212"
-  resolved "https://registry.yarnpkg.com/@aztec/noir-types/-/noir-types-3.0.0-devnet.20251212.tgz#878793c148d4305e0113963fdbdd4a4791fca01e"
-  integrity sha512-cFgkHsupyJmDkN/MEP7EDgG9pBKO4jGNH9Y3d3t0OIhRjlberBRv0HtlcfTfaKeM2DZ2x/Lloov+5J6mfuyMrA==
+"@aztec/noir-types@3.0.0-devnet.6-patch.1":
+  version "3.0.0-devnet.6-patch.1"
+  resolved "https://registry.yarnpkg.com/@aztec/noir-types/-/noir-types-3.0.0-devnet.6-patch.1.tgz#ce91b70427983bf32bb013d6c86b0b2e348956c3"
+  integrity sha512-zj7/ERBvTcnypoytwk4RBiN4mBe1kRVZJpd9byUPc5p9vVqi2uYkbaLa1JpjwyKShItWXU6TXv6C8V23jj5mGA==
 
-"@aztec/protocol-contracts@3.0.0-devnet.20251212":
-  version "3.0.0-devnet.20251212"
-  resolved "https://registry.yarnpkg.com/@aztec/protocol-contracts/-/protocol-contracts-3.0.0-devnet.20251212.tgz#d08620926a4370995b58a2ba4341a8324d82b8ab"
-  integrity sha512-AZSTimslrwiyc4d3doifGQcUmayuYDZkD+Eo/U9udIz4uexljVgOVCNMbciDbDGDuEkKEd6mg/W/YlAcTqCdqQ==
+"@aztec/protocol-contracts@3.0.0-devnet.6-patch.1":
+  version "3.0.0-devnet.6-patch.1"
+  resolved "https://registry.yarnpkg.com/@aztec/protocol-contracts/-/protocol-contracts-3.0.0-devnet.6-patch.1.tgz#b5a79b19041593744d776a0adb9c0e1f99d50ca7"
+  integrity sha512-QbpoSNLZ54xzAmeen3t+oJEKoeoqD84mrP+ooFgLNPwuXAU48BP5Otq3aZIycIfTcjXnjIhORzLURX0ftU3sKg==
   dependencies:
-    "@aztec/constants" "3.0.0-devnet.20251212"
-    "@aztec/foundation" "3.0.0-devnet.20251212"
-    "@aztec/stdlib" "3.0.0-devnet.20251212"
+    "@aztec/constants" "3.0.0-devnet.6-patch.1"
+    "@aztec/foundation" "3.0.0-devnet.6-patch.1"
+    "@aztec/stdlib" "3.0.0-devnet.6-patch.1"
     lodash.chunk "^4.2.0"
     lodash.omit "^4.5.0"
     tslib "^2.4.0"
 
-"@aztec/pxe@3.0.0-devnet.20251212":
-  version "3.0.0-devnet.20251212"
-  resolved "https://registry.yarnpkg.com/@aztec/pxe/-/pxe-3.0.0-devnet.20251212.tgz#dd9916163a41ed1c8532768ac8f92fa1e2426468"
-  integrity sha512-wmg2emJsutWNnHCuly+2t/C43PFEtGqoHzkCSsDhfgWDgjtaScROyaGoCHyNjqGDJvhfe5HQ+cfGjjEuYia0Qw==
+"@aztec/pxe@3.0.0-devnet.6-patch.1":
+  version "3.0.0-devnet.6-patch.1"
+  resolved "https://registry.yarnpkg.com/@aztec/pxe/-/pxe-3.0.0-devnet.6-patch.1.tgz#996f07b034f8f97a254ed4d5bc8814e339f9e709"
+  integrity sha512-ugKffEjNH+U6EfkVuXceozQhmbHgCtLmNx2Jxl02hzW44/41lmL05zAHXCL5IKi+5NfyaRmMjxFJ898jXKa8Lw==
   dependencies:
-    "@aztec/bb-prover" "3.0.0-devnet.20251212"
-    "@aztec/bb.js" "3.0.0-devnet.20251212"
-    "@aztec/builder" "3.0.0-devnet.20251212"
-    "@aztec/constants" "3.0.0-devnet.20251212"
-    "@aztec/ethereum" "3.0.0-devnet.20251212"
-    "@aztec/foundation" "3.0.0-devnet.20251212"
-    "@aztec/key-store" "3.0.0-devnet.20251212"
-    "@aztec/kv-store" "3.0.0-devnet.20251212"
-    "@aztec/noir-protocol-circuits-types" "3.0.0-devnet.20251212"
-    "@aztec/noir-types" "3.0.0-devnet.20251212"
-    "@aztec/protocol-contracts" "3.0.0-devnet.20251212"
-    "@aztec/simulator" "3.0.0-devnet.20251212"
-    "@aztec/stdlib" "3.0.0-devnet.20251212"
+    "@aztec/bb-prover" "3.0.0-devnet.6-patch.1"
+    "@aztec/bb.js" "3.0.0-devnet.6-patch.1"
+    "@aztec/builder" "3.0.0-devnet.6-patch.1"
+    "@aztec/constants" "3.0.0-devnet.6-patch.1"
+    "@aztec/ethereum" "3.0.0-devnet.6-patch.1"
+    "@aztec/foundation" "3.0.0-devnet.6-patch.1"
+    "@aztec/key-store" "3.0.0-devnet.6-patch.1"
+    "@aztec/kv-store" "3.0.0-devnet.6-patch.1"
+    "@aztec/noir-protocol-circuits-types" "3.0.0-devnet.6-patch.1"
+    "@aztec/noir-types" "3.0.0-devnet.6-patch.1"
+    "@aztec/protocol-contracts" "3.0.0-devnet.6-patch.1"
+    "@aztec/simulator" "3.0.0-devnet.6-patch.1"
+    "@aztec/stdlib" "3.0.0-devnet.6-patch.1"
     koa "^2.16.1"
     koa-router "^13.1.1"
     lodash.omit "^4.5.0"
@@ -874,39 +874,39 @@
     tslib "^2.4.0"
     viem "npm:@aztec/viem@2.38.2"
 
-"@aztec/simulator@3.0.0-devnet.20251212":
-  version "3.0.0-devnet.20251212"
-  resolved "https://registry.yarnpkg.com/@aztec/simulator/-/simulator-3.0.0-devnet.20251212.tgz#da2f87175593acbb6a830c99a7e4a0992d3897b7"
-  integrity sha512-juVBLvDEMBPkzg6gaxtRGeuBiPq35S1BEI1L5Y1z1GHZXvrPxR/R8Q2YrG8wBgdNvfPtXCFXDlW1FF2AFtORtA==
+"@aztec/simulator@3.0.0-devnet.6-patch.1":
+  version "3.0.0-devnet.6-patch.1"
+  resolved "https://registry.yarnpkg.com/@aztec/simulator/-/simulator-3.0.0-devnet.6-patch.1.tgz#0c22af0f6be531c8b32b0f735a3e8ae207530cb7"
+  integrity sha512-nDXLLCYMDVTCi8uUUBGO715f4Q+KyoKPa8p0bpJ/08y99aPT67BoouUJE0XXAv44MbQcLgt1SO0dwdW9Cc81Tg==
   dependencies:
-    "@aztec/constants" "3.0.0-devnet.20251212"
-    "@aztec/foundation" "3.0.0-devnet.20251212"
-    "@aztec/native" "3.0.0-devnet.20251212"
-    "@aztec/noir-acvm_js" "3.0.0-devnet.20251212"
-    "@aztec/noir-noirc_abi" "3.0.0-devnet.20251212"
-    "@aztec/noir-protocol-circuits-types" "3.0.0-devnet.20251212"
-    "@aztec/noir-types" "3.0.0-devnet.20251212"
-    "@aztec/protocol-contracts" "3.0.0-devnet.20251212"
-    "@aztec/stdlib" "3.0.0-devnet.20251212"
-    "@aztec/telemetry-client" "3.0.0-devnet.20251212"
-    "@aztec/world-state" "3.0.0-devnet.20251212"
+    "@aztec/constants" "3.0.0-devnet.6-patch.1"
+    "@aztec/foundation" "3.0.0-devnet.6-patch.1"
+    "@aztec/native" "3.0.0-devnet.6-patch.1"
+    "@aztec/noir-acvm_js" "3.0.0-devnet.6-patch.1"
+    "@aztec/noir-noirc_abi" "3.0.0-devnet.6-patch.1"
+    "@aztec/noir-protocol-circuits-types" "3.0.0-devnet.6-patch.1"
+    "@aztec/noir-types" "3.0.0-devnet.6-patch.1"
+    "@aztec/protocol-contracts" "3.0.0-devnet.6-patch.1"
+    "@aztec/stdlib" "3.0.0-devnet.6-patch.1"
+    "@aztec/telemetry-client" "3.0.0-devnet.6-patch.1"
+    "@aztec/world-state" "3.0.0-devnet.6-patch.1"
     lodash.clonedeep "^4.5.0"
     lodash.merge "^4.6.2"
     tslib "^2.4.0"
 
-"@aztec/stdlib@3.0.0-devnet.20251212":
-  version "3.0.0-devnet.20251212"
-  resolved "https://registry.yarnpkg.com/@aztec/stdlib/-/stdlib-3.0.0-devnet.20251212.tgz#e87ea64a15137aaa55395f30278ba184a3928f97"
-  integrity sha512-dynBZhet96Uq4xXM4oqRUcD/7E6pJXK3yVQH5cpCUEzk47vzDeQCdbRiIJJ+QEM5SVIjx2PG0fct1nFXcCD5Hw==
+"@aztec/stdlib@3.0.0-devnet.6-patch.1":
+  version "3.0.0-devnet.6-patch.1"
+  resolved "https://registry.yarnpkg.com/@aztec/stdlib/-/stdlib-3.0.0-devnet.6-patch.1.tgz#0f82be8011843165519293f11e9ec9c43bc86a5f"
+  integrity sha512-nljgFQ046BKWg10HTiYD/UjrC8rWs+8nRFWMVeAPrLiX0mWrjjMHkqag480U2ROO4YpdqqgbVujnNmQa/cLzuA==
   dependencies:
     "@aws-sdk/client-s3" "^3.892.0"
-    "@aztec/bb.js" "3.0.0-devnet.20251212"
-    "@aztec/blob-lib" "3.0.0-devnet.20251212"
-    "@aztec/constants" "3.0.0-devnet.20251212"
-    "@aztec/ethereum" "3.0.0-devnet.20251212"
-    "@aztec/foundation" "3.0.0-devnet.20251212"
-    "@aztec/l1-artifacts" "3.0.0-devnet.20251212"
-    "@aztec/noir-noirc_abi" "3.0.0-devnet.20251212"
+    "@aztec/bb.js" "3.0.0-devnet.6-patch.1"
+    "@aztec/blob-lib" "3.0.0-devnet.6-patch.1"
+    "@aztec/constants" "3.0.0-devnet.6-patch.1"
+    "@aztec/ethereum" "3.0.0-devnet.6-patch.1"
+    "@aztec/foundation" "3.0.0-devnet.6-patch.1"
+    "@aztec/l1-artifacts" "3.0.0-devnet.6-patch.1"
+    "@aztec/noir-noirc_abi" "3.0.0-devnet.6-patch.1"
     "@google-cloud/storage" "^7.15.0"
     axios "^1.12.0"
     json-stringify-deterministic "1.0.12"
@@ -920,13 +920,13 @@
     viem "npm:@aztec/viem@2.38.2"
     zod "^3.23.8"
 
-"@aztec/telemetry-client@3.0.0-devnet.20251212":
-  version "3.0.0-devnet.20251212"
-  resolved "https://registry.yarnpkg.com/@aztec/telemetry-client/-/telemetry-client-3.0.0-devnet.20251212.tgz#7cef701d20f1adcdde6508c1dc101a638e830db0"
-  integrity sha512-Q77CD74Y+aCiisqdXvitYF31/3N5No5CKSf5w/DsL5WKpyiIsW0fEM09QBIhEz3JUCh9J7jG4cz7PaNQ5xoyQg==
+"@aztec/telemetry-client@3.0.0-devnet.6-patch.1":
+  version "3.0.0-devnet.6-patch.1"
+  resolved "https://registry.yarnpkg.com/@aztec/telemetry-client/-/telemetry-client-3.0.0-devnet.6-patch.1.tgz#599032472c50ffe1d45641e9568ff1cae99c46b0"
+  integrity sha512-XZeLKSf2ws+2VEzGDESBkFo8kI9BGNTRXHpAJZ7NIFCbEGBwb44N0Rf8S8BBJgixARg7iUaiiFs2y2mBf3b2Gg==
   dependencies:
-    "@aztec/foundation" "3.0.0-devnet.20251212"
-    "@aztec/stdlib" "3.0.0-devnet.20251212"
+    "@aztec/foundation" "3.0.0-devnet.6-patch.1"
+    "@aztec/stdlib" "3.0.0-devnet.6-patch.1"
     "@opentelemetry/api" "^1.9.0"
     "@opentelemetry/api-logs" "^0.55.0"
     "@opentelemetry/core" "^1.28.0"
@@ -944,45 +944,45 @@
     prom-client "^15.1.3"
     viem "npm:@aztec/viem@2.38.2"
 
-"@aztec/test-wallet@3.0.0-devnet.20251212":
-  version "3.0.0-devnet.20251212"
-  resolved "https://registry.yarnpkg.com/@aztec/test-wallet/-/test-wallet-3.0.0-devnet.20251212.tgz#b72ec3502dc7361850a94c25684f167afa6a6322"
-  integrity sha512-f2rqo8YPOtPrDsPnjYFdYb8bg1uWYAQvtN+jYYTKT9m2EuqJ8e9urXbifG2Qpa4WkLzycYFbhO/lwwwnJ8OD8A==
+"@aztec/test-wallet@3.0.0-devnet.6-patch.1":
+  version "3.0.0-devnet.6-patch.1"
+  resolved "https://registry.yarnpkg.com/@aztec/test-wallet/-/test-wallet-3.0.0-devnet.6-patch.1.tgz#fc70b9c639ed77d1a04d449f2aaf36f5bfeee784"
+  integrity sha512-K9jZrWN2XKzLm9X3prLwuvNPFKf9q+jc6jnuesHAMDsLDMDjG5YYBlLfYYHsNI6DbpHT0CxGDgPFuK4qYB3Dqg==
   dependencies:
-    "@aztec/accounts" "3.0.0-devnet.20251212"
-    "@aztec/aztec.js" "3.0.0-devnet.20251212"
-    "@aztec/entrypoints" "3.0.0-devnet.20251212"
-    "@aztec/foundation" "3.0.0-devnet.20251212"
-    "@aztec/noir-contracts.js" "3.0.0-devnet.20251212"
-    "@aztec/pxe" "3.0.0-devnet.20251212"
-    "@aztec/stdlib" "3.0.0-devnet.20251212"
-    "@aztec/wallet-sdk" "3.0.0-devnet.20251212"
+    "@aztec/accounts" "3.0.0-devnet.6-patch.1"
+    "@aztec/aztec.js" "3.0.0-devnet.6-patch.1"
+    "@aztec/entrypoints" "3.0.0-devnet.6-patch.1"
+    "@aztec/foundation" "3.0.0-devnet.6-patch.1"
+    "@aztec/noir-contracts.js" "3.0.0-devnet.6-patch.1"
+    "@aztec/pxe" "3.0.0-devnet.6-patch.1"
+    "@aztec/stdlib" "3.0.0-devnet.6-patch.1"
+    "@aztec/wallet-sdk" "3.0.0-devnet.6-patch.1"
 
-"@aztec/wallet-sdk@3.0.0-devnet.20251212":
-  version "3.0.0-devnet.20251212"
-  resolved "https://registry.yarnpkg.com/@aztec/wallet-sdk/-/wallet-sdk-3.0.0-devnet.20251212.tgz#bd0e5c646582f8b73e93b6aa5c2748d1ea446f17"
-  integrity sha512-ZpH6cZgxON1S38dwKKkY2xDpjJ53G3AGOGYU4PqF6H1TXTISWxvrM/zCnt5JokGQtz+vDkze2A0rm/JtgVUebg==
+"@aztec/wallet-sdk@3.0.0-devnet.6-patch.1":
+  version "3.0.0-devnet.6-patch.1"
+  resolved "https://registry.yarnpkg.com/@aztec/wallet-sdk/-/wallet-sdk-3.0.0-devnet.6-patch.1.tgz#1ec5ac27f6d5b29758606457712c7966325b74a0"
+  integrity sha512-acshskh0gWYwanEDpc2lfwAuoexsf0halQsJRCFjMgkRW1nryEUefBGsRe0Ztq572OVNCpd8KpJRzDl4OcVjPg==
   dependencies:
-    "@aztec/aztec.js" "3.0.0-devnet.20251212"
-    "@aztec/constants" "3.0.0-devnet.20251212"
-    "@aztec/entrypoints" "3.0.0-devnet.20251212"
-    "@aztec/foundation" "3.0.0-devnet.20251212"
-    "@aztec/pxe" "3.0.0-devnet.20251212"
-    "@aztec/stdlib" "3.0.0-devnet.20251212"
+    "@aztec/aztec.js" "3.0.0-devnet.6-patch.1"
+    "@aztec/constants" "3.0.0-devnet.6-patch.1"
+    "@aztec/entrypoints" "3.0.0-devnet.6-patch.1"
+    "@aztec/foundation" "3.0.0-devnet.6-patch.1"
+    "@aztec/pxe" "3.0.0-devnet.6-patch.1"
+    "@aztec/stdlib" "3.0.0-devnet.6-patch.1"
 
-"@aztec/world-state@3.0.0-devnet.20251212":
-  version "3.0.0-devnet.20251212"
-  resolved "https://registry.yarnpkg.com/@aztec/world-state/-/world-state-3.0.0-devnet.20251212.tgz#a376363b92db3c37041611499f592849851d288a"
-  integrity sha512-YcivSND09IFwOJGuzd+KxCcey5voU0KkgDUvSXSv/l0OZQR3o1OBWO9in08GseF4FQI3SZSuLzM3hhuPwMPLgg==
+"@aztec/world-state@3.0.0-devnet.6-patch.1":
+  version "3.0.0-devnet.6-patch.1"
+  resolved "https://registry.yarnpkg.com/@aztec/world-state/-/world-state-3.0.0-devnet.6-patch.1.tgz#78b8cc83a67ca612d55e431219f2ac497ac4803e"
+  integrity sha512-6/svpdxdb/XkBGu+YH+EJZpnyCTyg4oZ31Mm1RsnYRUYz6gyZjh6w0CuiIPP3FOhnzfnvBCNrzcVK3apv7FImg==
   dependencies:
-    "@aztec/constants" "3.0.0-devnet.20251212"
-    "@aztec/foundation" "3.0.0-devnet.20251212"
-    "@aztec/kv-store" "3.0.0-devnet.20251212"
-    "@aztec/merkle-tree" "3.0.0-devnet.20251212"
-    "@aztec/native" "3.0.0-devnet.20251212"
-    "@aztec/protocol-contracts" "3.0.0-devnet.20251212"
-    "@aztec/stdlib" "3.0.0-devnet.20251212"
-    "@aztec/telemetry-client" "3.0.0-devnet.20251212"
+    "@aztec/constants" "3.0.0-devnet.6-patch.1"
+    "@aztec/foundation" "3.0.0-devnet.6-patch.1"
+    "@aztec/kv-store" "3.0.0-devnet.6-patch.1"
+    "@aztec/merkle-tree" "3.0.0-devnet.6-patch.1"
+    "@aztec/native" "3.0.0-devnet.6-patch.1"
+    "@aztec/protocol-contracts" "3.0.0-devnet.6-patch.1"
+    "@aztec/stdlib" "3.0.0-devnet.6-patch.1"
+    "@aztec/telemetry-client" "3.0.0-devnet.6-patch.1"
     tslib "^2.4.0"
     zod "^3.23.8"
 


### PR DESCRIPTION
## Summary

- Update all examples to use Aztec v3.0.0-devnet.6-patch.1 for consistency
- Switch Nargo.toml dependencies to use the cleaner `aztec-nr` repo format
- Update npm package versions in all package.json files
- Fix test-wallet-webapp to work with new PrivateVoting contract API

## Changes

### Nargo.toml Updates
All contracts now use the shorter `aztec-nr` dependency format:
```toml
# Before
aztec = { git = "https://github.com/AztecProtocol/aztec-packages/", tag = "...", directory = "noir-projects/aztec-nr/aztec" }

# After  
aztec = { git = "https://github.com/AztecProtocol/aztec-nr/", tag = "v3.0.0-devnet.6-patch.1", directory = "aztec" }
```

### Package.json Updates
All npm dependencies updated to `3.0.0-devnet.6-patch.1`

### API Fix
Fixed `test-wallet-webapp` to use the new `cast_vote` signature:
```typescript
// Before
cast_vote(1n)

// After
cast_vote({ id: 1n }, 1n)
```

### Files Changed
- `.github/workflows/*.yml` - Updated AZTEC_VERSION
- `*/Nargo.toml` - Updated dependency versions and format
- `*/package.json` - Updated npm versions
- `*/README.md` - Updated version references
- `CLAUDE.md` - Updated to reflect unified versioning
- `test-wallet-webapp/src/App.tsx` - Fixed cast_vote API call

## Test plan

- [x] recursive_verification: 5/5 tests passed
- [x] note-send-proof: 3/3 tests passed
- [x] prediction-market: 9/9 e2e + 10/10 Noir tests passed
- [x] account-contract: compiles successfully
- [x] custom-note: compiles successfully
- [x] test-wallet-webapp: builds successfully

🤖 Generated with [Claude Code](https://claude.ai/code)